### PR TITLE
Add MCP server for external agent integration (#20)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,17 +6,22 @@
       "name": "cc-dev-team",
       "dependencies": {
         "@lydell/node-pty-darwin-arm64": "^1.2.0-beta.7",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "@supabase/supabase-js": "^2.99.0",
+        "bcryptjs": "^3.0.3",
         "drizzle-orm": "^0.45.1",
         "next": "^16.1.6",
         "node-pty": "^1.1.0",
         "postgres": "^3.4.8",
         "socket.io": "^4.7.4",
         "socket.io-client": "^4.7.4",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "drizzle-kit": "^0.31.9",
+        "typescript": "^5.9.3",
         "vitest": "^3.0.0",
       },
     },
@@ -94,6 +99,8 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
+
     "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
 
     "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
@@ -157,6 +164,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@lydell/node-pty-darwin-arm64": ["@lydell/node-pty-darwin-arm64@1.2.0-beta.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WKP1EpR3SIIb5x6Su7OuAfiMmEjT3I9x6iICyF6s20gMxwHtRXVmFVwCDyI5/Ekj0cnhRzbzCLP1vxZgXIyT2A=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
     "@next/env": ["@next/env@16.1.6", "", {}, "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ=="],
 
@@ -244,6 +253,8 @@
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
+    "@types/bcryptjs": ["@types/bcryptjs@3.0.0", "", { "dependencies": { "bcryptjs": "*" } }, "sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/cors": ["@types/cors@2.8.19", "", { "dependencies": { "@types/node": "*" } }, "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg=="],
@@ -276,6 +287,10 @@
 
     "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
+    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -290,11 +305,21 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
+    "bcryptjs": ["bcryptjs@3.0.3", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
 
@@ -308,7 +333,13 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
@@ -318,15 +349,23 @@
 
     "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.9", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "engine.io": ["engine.io@6.6.5", "", { "dependencies": { "@types/cors": "^2.8.12", "@types/node": ">=10.0.0", "accepts": "~1.3.4", "base64id": "2.0.0", "cookie": "~0.7.2", "cors": "~2.8.5", "debug": "~4.4.1", "engine.io-parser": "~5.2.1", "ws": "~8.18.3" } }, "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A=="],
 
@@ -334,33 +373,87 @@
 
     "engine.io-parser": ["engine.io-parser@5.2.3", "", {}, "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.3.1", "", { "dependencies": { "ip-address": "10.1.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
+
+    "hono": ["hono@4.12.7", "", {}, "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw=="],
 
     "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
 
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "iceberg-js": ["iceberg-js@0.8.1", "", {}, "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA=="],
 
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.1.0", "", {}, "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -374,7 +467,13 @@
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
@@ -386,9 +485,15 @@
 
     "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -408,11 +513,21 @@
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -422,27 +537,57 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.3", "", { "bin": "bin/semver.js" }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
     "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
 
@@ -463,6 +608,8 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
@@ -494,9 +641,17 @@
 
     "tinyspy": ["tinyspy@4.0.4", "", {}, "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
@@ -514,11 +669,21 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
+    "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
@@ -581,6 +746,10 @@
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -20,17 +20,22 @@
   },
   "dependencies": {
     "@lydell/node-pty-darwin-arm64": "^1.2.0-beta.7",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "@supabase/supabase-js": "^2.99.0",
+    "bcryptjs": "^3.0.3",
     "drizzle-orm": "^0.45.1",
     "next": "^16.1.6",
     "node-pty": "^1.1.0",
     "postgres": "^3.4.8",
     "socket.io": "^4.7.4",
-    "socket.io-client": "^4.7.4"
+    "socket.io-client": "^4.7.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/bcryptjs": "^3.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "drizzle-kit": "^0.31.9",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   }
 }

--- a/src/app/api/mcp/auth.ts
+++ b/src/app/api/mcp/auth.ts
@@ -1,0 +1,38 @@
+import bcrypt from 'bcryptjs'
+import { createAdminClient } from '../../../db/supabase'
+
+export interface AuthContext {
+  tenantId: string
+}
+
+/**
+ * Authenticate a tenant via CDT API key from the Authorization header.
+ * Keys follow the format: "Bearer cdt_xxxx..."
+ * Lookup by prefix (fast filter), then bcrypt verify.
+ */
+export async function authenticateTenant(authHeader: string): Promise<AuthContext | null> {
+  if (!authHeader?.startsWith('Bearer ')) return null
+  const key = authHeader.slice(7)
+  if (!key.startsWith('cdt_')) return null
+
+  const supabase = createAdminClient()
+
+  const prefix = key.substring(0, 8)
+  const { data: candidates } = await supabase
+    .from('cdt_api_keys')
+    .select('id, tenant_id, key_hash')
+    .eq('key_prefix', prefix)
+
+  for (const candidate of candidates || []) {
+    if (await bcrypt.compare(key, candidate.key_hash)) {
+      // Update last_used timestamp (fire-and-forget)
+      await supabase
+        .from('cdt_api_keys')
+        .update({ last_used: new Date().toISOString() })
+        .eq('id', candidate.id)
+
+      return { tenantId: candidate.tenant_id }
+    }
+  }
+  return null
+}

--- a/src/app/api/mcp/errors.ts
+++ b/src/app/api/mcp/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * MCP error codes following JSON-RPC conventions.
+ * Maps to HTTP status equivalents for transport layer.
+ */
+export const McpErrorCode = {
+  UNAUTHORIZED: -32001,
+  NOT_FOUND: -32002,
+  SERVICE_UNAVAILABLE: -32003,
+  CONFLICT: -32004,
+  INVALID_REQUEST: -32600,
+} as const
+
+export class McpError extends Error {
+  code: number
+
+  constructor(code: number, message: string) {
+    super(message)
+    this.name = 'McpError'
+    this.code = code
+  }
+}

--- a/src/app/api/mcp/resources/project-activity.ts
+++ b/src/app/api/mcp/resources/project-activity.ts
@@ -1,0 +1,59 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { McpError, McpErrorCode } from '../errors'
+
+export async function readProjectActivity(projectId: string, tenantId: string) {
+  const supabase = createAdminClient()
+
+  // Verify tenant owns project
+  const { data: projects } = await supabase
+    .from('projects')
+    .select('id')
+    .eq('id', projectId)
+    .eq('tenant_id', tenantId)
+
+  if (!projects?.[0]) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Project "${projectId}" not found`)
+  }
+
+  // Get recent tasks
+  const { data: tasks } = await supabase
+    .from('tasks')
+    .select('id, title, status, submitted_at, completed_at')
+    .eq('project_id', projectId)
+    .order('submitted_at', { ascending: false })
+    .limit(20)
+
+  // Get recent PM outbox messages
+  const { data: messages } = await supabase
+    .from('pm_outbox')
+    .select('id, type, content, created_at, task_id')
+    .eq('tenant_id', tenantId)
+    .order('created_at', { ascending: false })
+    .limit(20)
+
+  // Filter messages to those belonging to tasks in this project
+  const taskIds = new Set((tasks ?? []).map((t: any) => t.id))
+  const projectMessages = (messages ?? []).filter((m: any) => taskIds.has(m.task_id))
+
+  // Merge and sort by timestamp
+  const events = [
+    ...(tasks ?? []).map((t: any) => ({
+      type: 'task',
+      id: t.id,
+      title: t.title,
+      status: t.status,
+      timestamp: t.submitted_at,
+    })),
+    ...projectMessages.map((m: any) => ({
+      type: 'message',
+      id: m.id,
+      message_type: m.type,
+      content: m.content,
+      task_id: m.task_id,
+      timestamp: m.created_at,
+    })),
+  ].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+    .slice(0, 20)
+
+  return { events }
+}

--- a/src/app/api/mcp/resources/project-overview.ts
+++ b/src/app/api/mcp/resources/project-overview.ts
@@ -1,0 +1,45 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { McpError, McpErrorCode } from '../errors'
+
+export async function readProjectOverview(projectId: string, tenantId: string) {
+  const supabase = createAdminClient()
+
+  const { data: projects } = await supabase
+    .from('projects')
+    .select('*')
+    .eq('id', projectId)
+    .eq('tenant_id', tenantId)
+
+  const project = projects?.[0]
+  if (!project) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Project "${projectId}" not found`)
+  }
+
+  // Get latest task info
+  const { data: tasks } = await supabase
+    .from('tasks')
+    .select('id, title, status')
+    .eq('project_id', projectId)
+    .order('submitted_at', { ascending: false })
+    .limit(1)
+
+  // Get machine status
+  const { data: machines } = await supabase
+    .from('machines')
+    .select('status, agents')
+    .eq('project_id', projectId)
+    .in('status', ['running', 'idle', 'starting'])
+    .limit(1)
+
+  return {
+    id: project.id,
+    name: project.name,
+    repo_url: project.repo_url,
+    description: project.description,
+    status: project.status,
+    provider_config: project.provider_config,
+    active_task: tasks?.[0] ?? null,
+    machine_status: machines?.[0]?.status ?? 'stopped',
+    agents_active: machines?.[0]?.agents ?? [],
+  }
+}

--- a/src/app/api/mcp/resources/project-tasks.ts
+++ b/src/app/api/mcp/resources/project-tasks.ts
@@ -1,0 +1,41 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { McpError, McpErrorCode } from '../errors'
+
+export async function readProjectTasks(projectId: string, tenantId: string) {
+  const supabase = createAdminClient()
+
+  // Verify tenant owns project
+  const { data: projects } = await supabase
+    .from('projects')
+    .select('id')
+    .eq('id', projectId)
+    .eq('tenant_id', tenantId)
+
+  if (!projects?.[0]) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Project "${projectId}" not found`)
+  }
+
+  const { data: tasks } = await supabase
+    .from('tasks')
+    .select('*')
+    .eq('project_id', projectId)
+    .order('submitted_at', { ascending: false })
+
+  return {
+    tasks: (tasks ?? []).map((t: any) => ({
+      id: t.id,
+      title: t.title,
+      description: t.description,
+      status: t.status,
+      priority: t.priority,
+      submitted_at: t.submitted_at,
+      started_at: t.started_at,
+      completed_at: t.completed_at,
+      pr_url: t.github_pr_url,
+      issue_url: t.github_issue_url,
+      cost: t.cost_tokens
+        ? { tokens: t.cost_tokens, usd: parseFloat(t.cost_usd ?? '0') }
+        : null,
+    })),
+  }
+}

--- a/src/app/api/mcp/route.ts
+++ b/src/app/api/mcp/route.ts
@@ -1,0 +1,100 @@
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { authenticateTenant } from './auth'
+import { createServer } from './server'
+import { McpErrorCode } from './errors'
+
+// Simple in-memory rate limiting (resets per serverless function lifecycle)
+const requestCounts = new Map<string, { count: number; resetAt: number }>()
+
+const RATE_LIMIT = 100
+const RATE_WINDOW_MS = 60 * 1000
+
+function checkRateLimit(tenantId: string): { remaining: number; resetAt: number } {
+  const now = Date.now()
+  let entry = requestCounts.get(tenantId)
+
+  if (!entry || now > entry.resetAt) {
+    entry = { count: 0, resetAt: now + RATE_WINDOW_MS }
+    requestCounts.set(tenantId, entry)
+  }
+
+  entry.count++
+  return { remaining: Math.max(0, RATE_LIMIT - entry.count), resetAt: entry.resetAt }
+}
+
+function rateLimitHeaders(remaining: number, resetAt: number): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(RATE_LIMIT),
+    'X-RateLimit-Remaining': String(remaining),
+    'X-RateLimit-Reset': String(Math.ceil(resetAt / 1000)),
+  }
+}
+
+function jsonError(code: number, message: string, httpStatus: number) {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: '2.0',
+      error: { code, message },
+      id: null,
+    }),
+    {
+      status: httpStatus,
+      headers: { 'Content-Type': 'application/json' },
+    }
+  )
+}
+
+async function handleMcpRequest(request: Request): Promise<Response> {
+  // Authenticate
+  const authHeader = request.headers.get('authorization') ?? ''
+  const auth = await authenticateTenant(authHeader)
+
+  if (!auth) {
+    return jsonError(McpErrorCode.UNAUTHORIZED, 'Unauthorized', 401)
+  }
+
+  // Rate limiting
+  const { remaining, resetAt } = checkRateLimit(auth.tenantId)
+
+  // Create per-request MCP server with auth context
+  const mcpServer = createServer(auth)
+
+  // Stateless transport (Vercel serverless — no persistent sessions)
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined, // Stateless mode
+    enableJsonResponse: true,
+  })
+
+  await mcpServer.connect(transport)
+
+  try {
+    const response = await transport.handleRequest(request)
+
+    // Add rate limit headers to response
+    const headers = new Headers(response.headers)
+    for (const [key, value] of Object.entries(rateLimitHeaders(remaining, resetAt))) {
+      headers.set(key, value)
+    }
+
+    return new Response(response.body, {
+      status: response.status,
+      headers,
+    })
+  } finally {
+    await mcpServer.close()
+  }
+}
+
+export async function POST(request: Request) {
+  return handleMcpRequest(request)
+}
+
+export async function GET(request: Request) {
+  return handleMcpRequest(request)
+}
+
+export async function DELETE(request: Request) {
+  // Session termination — stateless mode doesn't need this,
+  // but return a valid response per MCP spec
+  return new Response(null, { status: 405 })
+}

--- a/src/app/api/mcp/server.ts
+++ b/src/app/api/mcp/server.ts
@@ -1,0 +1,163 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
+import { handleSubmitTask } from './tools/submit-task'
+import { handleGetTaskStatus } from './tools/get-task-status'
+import { handleCheckMessages } from './tools/check-messages'
+import { handleReplyToMessage } from './tools/reply-to-message'
+import { readProjectOverview } from './resources/project-overview'
+import { readProjectActivity } from './resources/project-activity'
+import { readProjectTasks } from './resources/project-tasks'
+import { McpError } from './errors'
+import type { AuthContext } from './auth'
+
+/**
+ * Create the MCP server instance with all tools and resources registered.
+ * The tenantId is injected per-request from the auth middleware.
+ */
+export function createServer(authContext: AuthContext) {
+  const server = new McpServer({
+    name: 'cc-dev-team',
+    version: '1.0.0',
+  })
+
+  // --- Tools ---
+
+  server.registerTool('submit_task', {
+    title: 'Submit Task',
+    description: 'Submit a new development task to a project. The task will be queued and a Fly Machine will be started to process it.',
+    inputSchema: {
+      project: z.string().describe('Project name'),
+      title: z.string().describe('Task title'),
+      description: z.string().describe('Task description — what to build or fix'),
+      priority: z.enum(['low', 'normal', 'high']).optional().describe('Priority level (default: normal)'),
+      provider_config: z.record(z.string(), z.object({
+        provider: z.string(),
+        model: z.string(),
+      })).optional().describe('Optional per-role model overrides'),
+    },
+  }, async ({ project, title, description, priority, provider_config }) => {
+    try {
+      const result = await handleSubmitTask({
+        tenantId: authContext.tenantId,
+        project,
+        title,
+        description,
+        priority,
+        provider_config: provider_config as Record<string, { provider: string; model: string }> | undefined,
+      })
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    } catch (err) {
+      if (err instanceof McpError) {
+        return { content: [{ type: 'text', text: err.message }], isError: true }
+      }
+      throw err
+    }
+  })
+
+  server.registerTool('get_task_status', {
+    title: 'Get Task Status',
+    description: 'Get the current status of a task including agent activity, blockers, and cost.',
+    inputSchema: {
+      task_id: z.string().uuid().describe('Task UUID'),
+    },
+  }, async ({ task_id }) => {
+    try {
+      const result = await handleGetTaskStatus({
+        tenantId: authContext.tenantId,
+        task_id,
+      })
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    } catch (err) {
+      if (err instanceof McpError) {
+        return { content: [{ type: 'text', text: err.message }], isError: true }
+      }
+      throw err
+    }
+  })
+
+  server.registerTool('check_messages', {
+    title: 'Check Messages',
+    description: 'Check for PM messages (questions, status updates, blockers, completion notices). Note: reading messages marks them as read.',
+    inputSchema: {
+      project: z.string().optional().describe('Filter by project name'),
+      unread_only: z.boolean().optional().describe('Only return unread messages (default: true)'),
+    },
+  }, async ({ project, unread_only }) => {
+    try {
+      const result = await handleCheckMessages({
+        tenantId: authContext.tenantId,
+        project,
+        unread_only,
+      })
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    } catch (err) {
+      if (err instanceof McpError) {
+        return { content: [{ type: 'text', text: err.message }], isError: true }
+      }
+      throw err
+    }
+  })
+
+  server.registerTool('reply_to_message', {
+    title: 'Reply to Message',
+    description: 'Reply to a PM message that requires a response (e.g., answering a question, approving a proposal).',
+    inputSchema: {
+      message_id: z.string().uuid().describe('PM outbox message UUID'),
+      response: z.string().describe('Your reply'),
+    },
+  }, async ({ message_id, response }) => {
+    try {
+      const result = await handleReplyToMessage({
+        tenantId: authContext.tenantId,
+        message_id,
+        response,
+      })
+      return { content: [{ type: 'text', text: JSON.stringify(result) }] }
+    } catch (err) {
+      if (err instanceof McpError) {
+        return { content: [{ type: 'text', text: err.message }], isError: true }
+      }
+      throw err
+    }
+  })
+
+  // --- Resources ---
+
+  server.registerResource(
+    'Project Overview',
+    new ResourceTemplate('project://{project_id}/overview', { list: undefined }),
+    {
+      description: 'Project name, repo URL, description, status, active task summary, and provider config.',
+    },
+    async (uri, { project_id }) => {
+      const data = await readProjectOverview(project_id as string, authContext.tenantId)
+      return { contents: [{ uri: uri.href, text: JSON.stringify(data), mimeType: 'application/json' }] }
+    }
+  )
+
+  server.registerResource(
+    'Project Activity',
+    new ResourceTemplate('project://{project_id}/activity', { list: undefined }),
+    {
+      description: 'Last 20 events (task submissions, completions, PM messages, status changes).',
+    },
+    async (uri, { project_id }) => {
+      const data = await readProjectActivity(project_id as string, authContext.tenantId)
+      return { contents: [{ uri: uri.href, text: JSON.stringify(data), mimeType: 'application/json' }] }
+    }
+  )
+
+  server.registerResource(
+    'Project Tasks',
+    new ResourceTemplate('project://{project_id}/tasks', { list: undefined }),
+    {
+      description: 'All tasks for the project with status, dates, cost, and PR URLs.',
+    },
+    async (uri, { project_id }) => {
+      const data = await readProjectTasks(project_id as string, authContext.tenantId)
+      return { contents: [{ uri: uri.href, text: JSON.stringify(data), mimeType: 'application/json' }] }
+    }
+  )
+
+  return server
+}

--- a/src/app/api/mcp/tools/check-messages.ts
+++ b/src/app/api/mcp/tools/check-messages.ts
@@ -1,0 +1,69 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { McpError, McpErrorCode } from '../errors'
+
+interface CheckMessagesInput {
+  tenantId: string
+  project?: string
+  unread_only?: boolean
+}
+
+export async function handleCheckMessages(input: CheckMessagesInput) {
+  const supabase = createAdminClient()
+  const unreadOnly = input.unread_only ?? true
+
+  // If project filter specified, resolve to project ID
+  let projectId: string | null = null
+  if (input.project) {
+    const { data: projects } = await supabase
+      .from('projects')
+      .select('id')
+      .eq('name', input.project)
+      .eq('tenant_id', input.tenantId)
+
+    if (!projects?.[0]) {
+      throw new McpError(McpErrorCode.NOT_FOUND, `Project "${input.project}" not found`)
+    }
+    projectId = projects[0].id
+  }
+
+  // Build query for pm_outbox joined with task info
+  let query = supabase
+    .from('pm_outbox')
+    .select('id, task_id, type, content, requires_response, response, created_at, read_at, tasks!inner(project_id, projects!inner(name))')
+    .eq('tenant_id', input.tenantId)
+
+  if (projectId) {
+    query = query.eq('tasks.project_id', projectId)
+  }
+
+  if (unreadOnly) {
+    query = query.is('read_at', null)
+  }
+
+  const { data: messages } = await query.order('created_at', { ascending: false })
+
+  // Mark returned unread messages as read
+  if (unreadOnly && messages?.length) {
+    const ids = messages.map((m: any) => m.id)
+    for (const id of ids) {
+      await supabase
+        .from('pm_outbox')
+        .update({ read_at: new Date().toISOString() })
+        .eq('id', id)
+    }
+  }
+
+  return {
+    messages: (messages || []).map((m: any) => ({
+      id: m.id,
+      task_id: m.task_id,
+      project_name: m.tasks?.projects?.name ?? 'unknown',
+      type: m.type,
+      content: m.content,
+      requires_response: m.requires_response,
+      response: m.response,
+      created_at: m.created_at,
+      read_at: m.read_at,
+    })),
+  }
+}

--- a/src/app/api/mcp/tools/get-task-status.ts
+++ b/src/app/api/mcp/tools/get-task-status.ts
@@ -1,0 +1,56 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { McpError, McpErrorCode } from '../errors'
+
+interface GetTaskStatusInput {
+  tenantId: string
+  task_id: string
+}
+
+export async function handleGetTaskStatus(input: GetTaskStatusInput) {
+  const supabase = createAdminClient()
+
+  // Query task, enforce tenant isolation
+  const { data: tasks } = await supabase
+    .from('tasks')
+    .select('*')
+    .eq('id', input.task_id)
+    .eq('tenant_id', input.tenantId)
+
+  const task = tasks?.[0]
+  if (!task) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Task "${input.task_id}" not found`)
+  }
+
+  // Query active machine for agent info
+  const { data: machines } = await supabase
+    .from('machines')
+    .select('agents')
+    .eq('project_id', task.project_id)
+    .in('status', ['running', 'idle', 'starting'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  // Query unresponded blockers
+  const { data: blockerRows } = await supabase
+    .from('pm_outbox')
+    .select('content')
+    .eq('task_id', task.id)
+    .eq('requires_response', true)
+    .is('response', null)
+
+  const agents = machines?.[0]?.agents
+  const blockers = blockerRows?.length ? blockerRows.map((b: any) => b.content) : null
+
+  return {
+    status: task.status,
+    title: task.title,
+    summary: task.result_summary ?? null,
+    agents_active: Array.isArray(agents) ? agents : [],
+    current_phase: task.status, // Derived from status for now
+    pr_url: task.github_pr_url ?? null,
+    blockers,
+    cost: task.cost_tokens
+      ? { tokens: task.cost_tokens, usd: parseFloat(task.cost_usd ?? '0') }
+      : null,
+  }
+}

--- a/src/app/api/mcp/tools/reply-to-message.ts
+++ b/src/app/api/mcp/tools/reply-to-message.ts
@@ -1,0 +1,66 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { findMachineForProject, injectMessage } from '../../../../lib/fly-machines'
+import { McpError, McpErrorCode } from '../errors'
+
+interface ReplyToMessageInput {
+  tenantId: string
+  message_id: string
+  response: string
+}
+
+export async function handleReplyToMessage(input: ReplyToMessageInput) {
+  const supabase = createAdminClient()
+
+  // Fetch pm_outbox row, verify tenant owns it
+  const { data: rows } = await supabase
+    .from('pm_outbox')
+    .select('id, tenant_id, task_id, requires_response, response')
+    .eq('id', input.message_id)
+    .eq('tenant_id', input.tenantId)
+
+  const message = rows?.[0]
+  if (!message) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Message "${input.message_id}" not found`)
+  }
+
+  // Guard: must require response and not already replied
+  if (!message.requires_response) {
+    throw new McpError(McpErrorCode.CONFLICT, 'Message does not require a response')
+  }
+  if (message.response !== null) {
+    throw new McpError(McpErrorCode.CONFLICT, 'Already responded to this message')
+  }
+
+  // Store the response
+  await supabase
+    .from('pm_outbox')
+    .update({
+      response: input.response,
+      responded_at: new Date().toISOString(),
+    })
+    .eq('id', message.id)
+
+  // Find the task to get project_id
+  const { data: taskRows } = await supabase
+    .from('tasks')
+    .select('id, project_id')
+    .eq('id', message.task_id)
+
+  const task = taskRows?.[0]
+  if (!task) {
+    return { ok: true, note: 'Response stored but task not found' }
+  }
+
+  // Try to inject into running machine
+  const machine = await findMachineForProject(task.project_id)
+  if (machine) {
+    await injectMessage(machine, {
+      to: 'pm',
+      type: 'HUMAN_RESPONSE',
+      content: input.response,
+    })
+    return { ok: true }
+  }
+
+  return { ok: true, note: 'Machine unavailable, response queued for next startup' }
+}

--- a/src/app/api/mcp/tools/submit-task.ts
+++ b/src/app/api/mcp/tools/submit-task.ts
@@ -1,0 +1,64 @@
+import { createAdminClient } from '../../../../db/supabase'
+import { ensureMachineRunning } from '../../../../lib/fly-machines'
+import { McpError, McpErrorCode } from '../errors'
+
+interface SubmitTaskInput {
+  tenantId: string
+  project: string
+  title: string
+  description: string
+  priority?: 'low' | 'normal' | 'high'
+  provider_config?: Record<string, { provider: string; model: string }>
+}
+
+const PRIORITY_MAP: Record<string, number> = {
+  low: 0,
+  normal: 1,
+  high: 2,
+}
+
+export async function handleSubmitTask(input: SubmitTaskInput) {
+  const supabase = createAdminClient()
+
+  // Resolve project by name, verify tenant owns it
+  const { data: projects } = await supabase
+    .from('projects')
+    .select('id, name')
+    .eq('name', input.project)
+    .eq('tenant_id', input.tenantId)
+
+  const project = projects?.[0]
+  if (!project) {
+    throw new McpError(McpErrorCode.NOT_FOUND, `Project "${input.project}" not found`)
+  }
+
+  // Insert task
+  const priority = PRIORITY_MAP[input.priority ?? 'normal'] ?? 1
+  const { data: tasks, error } = await supabase
+    .from('tasks')
+    .insert({
+      project_id: project.id,
+      tenant_id: input.tenantId,
+      title: input.title,
+      description: input.description,
+      priority,
+      status: 'queued',
+      metadata: input.provider_config ? { provider_config: input.provider_config } : null,
+    })
+    .select()
+
+  if (error || !tasks?.[0]) {
+    throw new McpError(McpErrorCode.SERVICE_UNAVAILABLE, 'Failed to create task')
+  }
+
+  const task = tasks[0]
+
+  // Try to ensure a Machine is running (best-effort)
+  try {
+    await ensureMachineRunning(project.id, input.tenantId)
+    return { task_id: task.id, status: task.status ?? 'queued' }
+  } catch {
+    // Machine creation failed, task stays queued
+    return { task_id: task.id, status: 'queued' }
+  }
+}

--- a/src/lib/fly-machines.ts
+++ b/src/lib/fly-machines.ts
@@ -1,0 +1,71 @@
+import { createAdminClient } from '../db/supabase'
+
+export interface Machine {
+  id: string
+  project_id: string
+  tenant_id: string
+  task_id: string | null
+  fly_machine_id: string | null
+  fly_app_name: string | null
+  status: string
+  agents: string[] | null
+  cost_summary: Record<string, unknown> | null
+}
+
+export interface InjectPayload {
+  to: string
+  type: string
+  content: string
+}
+
+/**
+ * Find a running Machine for a project.
+ * Queries the machines table for active instances.
+ */
+export async function findMachineForProject(projectId: string): Promise<Machine | null> {
+  // TODO: Implement with real Fly.io Machines API (#18)
+  // Currently queries Supabase for machine records
+  const supabase = createAdminClient()
+  const { data } = await supabase
+    .from('machines')
+    .select('*')
+    .eq('project_id', projectId)
+    .in('status', ['running', 'idle', 'starting'])
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  return (data?.[0] as Machine) || null
+}
+
+/**
+ * Inject a message into a running Machine's broker.
+ * Posts to the Machine's /api/inject-message endpoint.
+ */
+export async function injectMessage(machine: Machine, message: InjectPayload): Promise<void> {
+  // TODO: Implement with real Fly.io machine communication (#18)
+  // For now, log the intent - the broker will read queued messages on boot
+  console.log(`[fly-machines] Would inject message to ${machine.fly_app_name}:`, message)
+}
+
+/**
+ * Ensure a Machine is running for a project.
+ * Creates, starts, or reuses an existing Machine.
+ */
+export async function ensureMachineRunning(
+  projectId: string,
+  tenantId: string
+): Promise<Machine> {
+  // TODO: Implement with real Fly.io lifecycle management (#18)
+  // This stub returns mock data for development
+  return {
+    id: 'stub-machine-id',
+    project_id: projectId,
+    tenant_id: tenantId,
+    task_id: null,
+    fly_machine_id: 'stub-fly-id',
+    fly_app_name: 'cdt-stub',
+    status: 'starting',
+    agents: [],
+    cost_summary: null,
+  }
+}

--- a/tests/mcp/auth.test.ts
+++ b/tests/mcp/auth.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import bcrypt from 'bcryptjs'
+
+// Mock the DB module
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { authenticateTenant } from '../../src/app/api/mcp/auth'
+import { createAdminClient } from '../../src/db/supabase'
+
+function mockDb(rows: any[] = []) {
+  const query = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+  }
+  // Final .eq() returns the result
+  query.eq.mockImplementation(() => query)
+  // Override the last call to return data
+  const from = vi.fn().mockReturnValue(query)
+  const update = vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({}) })
+  const updateFrom = vi.fn().mockReturnValue({ update: vi.fn().mockReturnValue({ eq: vi.fn().mockResolvedValue({}) }) })
+
+  // Build a mock that handles both select and update chains
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'cdt_api_keys') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: rows }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({}),
+          }),
+        }
+      }
+      return { select: vi.fn().mockReturnThis(), eq: vi.fn() }
+    }),
+  }
+
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('authenticateTenant', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns null for missing auth header', async () => {
+    const result = await authenticateTenant('')
+    expect(result).toBeNull()
+  })
+
+  it('returns null for non-cdt_ prefix', async () => {
+    const result = await authenticateTenant('Bearer sk_test_abc123')
+    expect(result).toBeNull()
+  })
+
+  it('returns null for missing Bearer prefix', async () => {
+    const result = await authenticateTenant('cdt_abc12345rest')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when no matching key prefix found', async () => {
+    mockDb([])
+    const result = await authenticateTenant('Bearer cdt_abc12345rest')
+    expect(result).toBeNull()
+  })
+
+  it('returns null when bcrypt comparison fails', async () => {
+    mockDb([{
+      id: 'key-1',
+      tenant_id: 'tenant-1',
+      key_hash: await bcrypt.hash('cdt_different_key', 10),
+    }])
+    const result = await authenticateTenant('Bearer cdt_abc12345rest')
+    expect(result).toBeNull()
+  })
+
+  it('returns tenantId on valid key match', async () => {
+    const rawKey = 'cdt_validkey12345678'
+    const keyHash = await bcrypt.hash(rawKey, 10)
+    mockDb([{
+      id: 'key-1',
+      tenant_id: 'tenant-123',
+      key_hash: keyHash,
+    }])
+    const result = await authenticateTenant(`Bearer ${rawKey}`)
+    expect(result).toEqual({ tenantId: 'tenant-123' })
+  })
+
+  it('updates last_used timestamp on successful auth', async () => {
+    const rawKey = 'cdt_validkey12345678'
+    const keyHash = await bcrypt.hash(rawKey, 10)
+    const mockClient = mockDb([{
+      id: 'key-1',
+      tenant_id: 'tenant-123',
+      key_hash: keyHash,
+    }])
+    await authenticateTenant(`Bearer ${rawKey}`)
+
+    // Verify update was called (second call to from('cdt_api_keys'))
+    const calls = mockClient.from.mock.calls
+    const updateCalls = calls.filter((c: any) => c[0] === 'cdt_api_keys')
+    expect(updateCalls.length).toBe(2) // select + update
+  })
+})

--- a/tests/mcp/check-messages.test.ts
+++ b/tests/mcp/check-messages.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { handleCheckMessages } from '../../src/app/api/mcp/tools/check-messages'
+import { createAdminClient } from '../../src/db/supabase'
+
+function createChainableQuery(resolvedData: any) {
+  // Creates a proxy that returns itself for any chained method call,
+  // but resolves to { data } when awaited (via .then)
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === 'then') {
+        return (resolve: any) => resolve({ data: resolvedData })
+      }
+      return (..._args: any[]) => new Proxy({}, handler)
+    },
+  }
+  return new Proxy({}, handler)
+}
+
+function createTrackingQuery(resolvedData: any) {
+  // Like chainable query but tracks which methods were called
+  const calls: Array<{ method: string; args: any[] }> = []
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === 'then') {
+        return (resolve: any) => resolve({ data: resolvedData })
+      }
+      if (prop === '__calls') {
+        return calls
+      }
+      return (...args: any[]) => {
+        calls.push({ method: prop as string, args })
+        return new Proxy({}, handler)
+      }
+    },
+  }
+  return new Proxy({}, handler)
+}
+
+function mockDb(messages: any[] = [], projectRows: any[] = [{ id: 'proj-1' }]) {
+  let pmOutboxQuery: any
+  const updateCalls: any[] = []
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'pm_outbox') {
+        pmOutboxQuery = createTrackingQuery(messages)
+        return {
+          select: () => pmOutboxQuery,
+          update: vi.fn().mockImplementation((data: any) => {
+            updateCalls.push(data)
+            return { eq: vi.fn().mockResolvedValue({}) }
+          }),
+        }
+      }
+      if (table === 'projects') {
+        return {
+          select: () => createChainableQuery(projectRows),
+        }
+      }
+      return {}
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return { mockClient, getPmOutboxCalls: () => pmOutboxQuery?.__calls ?? [], updateCalls }
+}
+
+describe('handleCheckMessages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('returns empty messages array when none exist', async () => {
+    mockDb([])
+    const result = await handleCheckMessages({ tenantId: 'tenant-1' })
+    expect(result.messages).toEqual([])
+  })
+
+  it('returns messages with all expected fields', async () => {
+    const msg = {
+      id: 'msg-1',
+      task_id: 'task-1',
+      type: 'question',
+      content: 'Need clarification on requirements',
+      requires_response: true,
+      response: null,
+      created_at: '2026-03-10T00:00:00Z',
+      read_at: null,
+      tasks: { projects: { name: 'my-project' } },
+    }
+    mockDb([msg])
+
+    const result = await handleCheckMessages({ tenantId: 'tenant-1' })
+
+    expect(result.messages).toHaveLength(1)
+    expect(result.messages[0]).toMatchObject({
+      id: 'msg-1',
+      task_id: 'task-1',
+      type: 'question',
+      content: 'Need clarification on requirements',
+      requires_response: true,
+    })
+  })
+
+  it('defaults to unread_only=true and applies is(read_at, null) filter', async () => {
+    const { getPmOutboxCalls } = mockDb([])
+    await handleCheckMessages({ tenantId: 'tenant-1' })
+
+    const calls = getPmOutboxCalls()
+    const isCall = calls.find((c: any) => c.method === 'is')
+    expect(isCall).toBeDefined()
+    expect(isCall.args[0]).toBe('read_at')
+    expect(isCall.args[1]).toBeNull()
+  })
+
+  it('skips read_at filter when unread_only is false', async () => {
+    const { getPmOutboxCalls } = mockDb([])
+    await handleCheckMessages({ tenantId: 'tenant-1', unread_only: false })
+
+    const calls = getPmOutboxCalls()
+    const isCall = calls.find((c: any) => c.method === 'is')
+    expect(isCall).toBeUndefined()
+  })
+
+  it('filters by project when specified', async () => {
+    const { mockClient } = mockDb([], [{ id: 'proj-42' }])
+    await handleCheckMessages({ tenantId: 'tenant-1', project: 'my-project' })
+
+    // Verify projects table was queried for project resolution
+    const fromCalls = mockClient.from.mock.calls.map((c: any) => c[0])
+    expect(fromCalls).toContain('projects')
+  })
+
+  it('throws NOT_FOUND when project filter specifies nonexistent project', async () => {
+    mockDb([], []) // No project rows
+    await expect(
+      handleCheckMessages({ tenantId: 'tenant-1', project: 'nonexistent' })
+    ).rejects.toMatchObject({
+      code: -32002,
+      message: expect.stringContaining('not found'),
+    })
+  })
+
+  it('marks unread messages as read after retrieval', async () => {
+    const msg = {
+      id: 'msg-1',
+      task_id: 'task-1',
+      type: 'status_update',
+      content: 'Done',
+      requires_response: false,
+      response: null,
+      created_at: '2026-03-10T00:00:00Z',
+      read_at: null,
+      tasks: { projects: { name: 'proj' } },
+    }
+    const { updateCalls } = mockDb([msg])
+    await handleCheckMessages({ tenantId: 'tenant-1' })
+
+    expect(updateCalls.length).toBeGreaterThan(0)
+    expect(updateCalls[0]).toHaveProperty('read_at')
+  })
+})

--- a/tests/mcp/e2e.test.ts
+++ b/tests/mcp/e2e.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('../../src/lib/fly-machines', () => ({
+  ensureMachineRunning: vi.fn(),
+  findMachineForProject: vi.fn(),
+  injectMessage: vi.fn(),
+}))
+
+import { handleSubmitTask } from '../../src/app/api/mcp/tools/submit-task'
+import { handleGetTaskStatus } from '../../src/app/api/mcp/tools/get-task-status'
+import { handleCheckMessages } from '../../src/app/api/mcp/tools/check-messages'
+import { handleReplyToMessage } from '../../src/app/api/mcp/tools/reply-to-message'
+import { createAdminClient } from '../../src/db/supabase'
+import { ensureMachineRunning, findMachineForProject, injectMessage } from '../../src/lib/fly-machines'
+
+const TENANT_ID = 'tenant-e2e'
+const PROJECT = { id: 'proj-e2e', name: 'e2e-project' }
+
+/**
+ * Stateful mock DB that simulates Supabase behavior across
+ * the full submit -> check -> reply flow.
+ */
+function createStatefulMockDb() {
+  const store = {
+    tasks: [] as any[],
+    pm_outbox: [] as any[],
+  }
+
+  function createChain(rows: any[]): any {
+    let filteredRows = [...rows]
+    const chain: any = {}
+
+    chain.select = vi.fn().mockReturnValue(chain)
+    chain.eq = vi.fn().mockImplementation((_col: string, _val: any) => chain)
+    chain.in = vi.fn().mockReturnValue(chain)
+    chain.is = vi.fn().mockReturnValue(chain)
+    chain.order = vi.fn().mockReturnValue(chain)
+    chain.limit = vi.fn().mockReturnValue(chain)
+    chain.insert = vi.fn().mockImplementation((row: any) => {
+      const newRow = { ...row, id: row.id ?? `generated-${Date.now()}` }
+      // Store in our state
+      return createChain([newRow])
+    })
+    chain.update = vi.fn().mockImplementation((_data: any) => ({
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }))
+    chain.then = (resolve: any) => resolve({ data: filteredRows, error: null })
+
+    return chain
+  }
+
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'projects') {
+        return createChain([PROJECT])
+      }
+      if (table === 'tasks') {
+        return createChain(store.tasks)
+      }
+      if (table === 'pm_outbox') {
+        return createChain(store.pm_outbox)
+      }
+      if (table === 'machines') {
+        return createChain([])
+      }
+      return createChain([])
+    }),
+  }
+
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+
+  return {
+    mockClient,
+    store,
+    addTask(task: any) { store.tasks.push(task) },
+    addMessage(msg: any) { store.pm_outbox.push(msg) },
+  }
+}
+
+describe('E2E Flow: submit_task -> check_messages -> reply_to_message', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('completes the full task lifecycle flow', async () => {
+    const db = createStatefulMockDb()
+
+    // --- Step 1: Submit a task ---
+    const createdTask = { id: 'task-e2e-1', status: 'queued' }
+    db.addTask(createdTask)
+    vi.mocked(ensureMachineRunning).mockResolvedValue({ status: 'starting' } as any)
+
+    const submitResult = await handleSubmitTask({
+      tenantId: TENANT_ID,
+      project: PROJECT.name,
+      title: 'Build login page',
+      description: 'Implement OAuth login flow with GitHub provider',
+      priority: 'high',
+    })
+
+    expect(submitResult.task_id).toBeDefined()
+    expect(['queued', 'running']).toContain(submitResult.status)
+    expect(ensureMachineRunning).toHaveBeenCalledWith(PROJECT.id, TENANT_ID)
+    const taskId = submitResult.task_id
+
+    // --- Step 2: Get task status ---
+    // Update task state to simulate progress
+    db.store.tasks = [{
+      id: taskId,
+      title: 'Build login page',
+      status: 'running',
+      project_id: PROJECT.id,
+      result_summary: null,
+      github_pr_url: null,
+      cost_tokens: { input: 5000, output: 2000 },
+      cost_usd: '0.12',
+    }]
+
+    const statusResult = await handleGetTaskStatus({
+      tenantId: TENANT_ID,
+      task_id: taskId,
+    })
+
+    expect(statusResult.status).toBe('running')
+    expect(statusResult.title).toBe('Build login page')
+    expect(statusResult.cost).toEqual({
+      tokens: { input: 5000, output: 2000 },
+      usd: 0.12,
+    })
+
+    // --- Step 3: PM sends a question (simulated by adding to outbox) ---
+    const pmQuestion = {
+      id: 'msg-e2e-1',
+      task_id: taskId,
+      tenant_id: TENANT_ID,
+      type: 'question',
+      content: 'Should we support Google OAuth in addition to GitHub?',
+      requires_response: true,
+      response: null,
+      created_at: '2026-03-11T10:00:00Z',
+      read_at: null,
+      tasks: { project_id: PROJECT.id, projects: { name: PROJECT.name } },
+    }
+    db.addMessage(pmQuestion)
+
+    // --- Step 4: Check messages ---
+    const messagesResult = await handleCheckMessages({ tenantId: TENANT_ID })
+
+    expect(messagesResult.messages).toHaveLength(1)
+    expect(messagesResult.messages[0]).toMatchObject({
+      id: 'msg-e2e-1',
+      type: 'question',
+      content: 'Should we support Google OAuth in addition to GitHub?',
+      requires_response: true,
+      response: null,
+    })
+
+    // --- Step 5: Reply to the question ---
+    // Reset db mock so reply_to_message can find the message
+    db.store.pm_outbox = [pmQuestion]
+    db.store.tasks = [{ id: taskId, project_id: PROJECT.id }]
+
+    const mockMachine = { id: 'machine-1', fly_app_name: 'cdt-e2e' }
+    vi.mocked(findMachineForProject).mockResolvedValue(mockMachine as any)
+    vi.mocked(injectMessage).mockResolvedValue(undefined)
+
+    const replyResult = await handleReplyToMessage({
+      tenantId: TENANT_ID,
+      message_id: 'msg-e2e-1',
+      response: 'Yes, add Google OAuth as well. Use the same callback pattern.',
+    })
+
+    expect(replyResult.ok).toBe(true)
+    expect(injectMessage).toHaveBeenCalledWith(
+      mockMachine,
+      expect.objectContaining({
+        to: 'pm',
+        type: 'HUMAN_RESPONSE',
+        content: 'Yes, add Google OAuth as well. Use the same callback pattern.',
+      })
+    )
+  })
+
+  it('handles task submission when machine is unavailable', async () => {
+    const db = createStatefulMockDb()
+    db.addTask({ id: 'task-offline', status: 'queued' })
+    vi.mocked(ensureMachineRunning).mockRejectedValue(new Error('Fly API timeout'))
+
+    const result = await handleSubmitTask({
+      tenantId: TENANT_ID,
+      project: PROJECT.name,
+      title: 'Offline task',
+      description: 'Should still be queued',
+    })
+
+    expect(result.task_id).toBeDefined()
+    expect(result.status).toBe('queued')
+  })
+
+  it('handles reply when machine is stopped (response queued)', async () => {
+    const db = createStatefulMockDb()
+    db.store.pm_outbox = [{
+      id: 'msg-offline',
+      task_id: 'task-1',
+      tenant_id: TENANT_ID,
+      requires_response: true,
+      response: null,
+    }]
+    db.store.tasks = [{ id: 'task-1', project_id: PROJECT.id }]
+
+    vi.mocked(findMachineForProject).mockResolvedValue(null)
+
+    const result = await handleReplyToMessage({
+      tenantId: TENANT_ID,
+      message_id: 'msg-offline',
+      response: 'Answer stored for later',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.note).toContain('queued')
+    expect(injectMessage).not.toHaveBeenCalled()
+  })
+})

--- a/tests/mcp/get-task-status.test.ts
+++ b/tests/mcp/get-task-status.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { handleGetTaskStatus } from '../../src/app/api/mcp/tools/get-task-status'
+import { createAdminClient } from '../../src/db/supabase'
+
+function mockDb(taskRow: any = null, machineRow: any = null, blockers: any[] = []) {
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'tasks') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: taskRow ? [taskRow] : [] }),
+            }),
+          }),
+        }
+      }
+      if (table === 'machines') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              in: vi.fn().mockReturnValue({
+                order: vi.fn().mockReturnValue({
+                  limit: vi.fn().mockResolvedValue({ data: machineRow ? [machineRow] : [] }),
+                }),
+              }),
+            }),
+          }),
+        }
+      }
+      if (table === 'pm_outbox') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                is: vi.fn().mockResolvedValue({ data: blockers }),
+              }),
+            }),
+          }),
+        }
+      }
+      return {}
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('handleGetTaskStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws MCP error when task not found', async () => {
+    mockDb(null)
+    await expect(
+      handleGetTaskStatus({ tenantId: 'tenant-1', task_id: 'nonexistent' })
+    ).rejects.toMatchObject({
+      code: -32002,
+      message: expect.stringContaining('not found'),
+    })
+  })
+
+  it('returns task status with all fields', async () => {
+    const task = {
+      id: 'task-1',
+      title: 'Build feature',
+      status: 'running',
+      result_summary: null,
+      github_pr_url: null,
+      cost_tokens: { input: 1000, output: 500 },
+      cost_usd: '0.05',
+    }
+    const machine = {
+      agents: ['pm', 'engineer'],
+    }
+    mockDb(task, machine, [])
+
+    const result = await handleGetTaskStatus({ tenantId: 'tenant-1', task_id: 'task-1' })
+
+    expect(result.status).toBe('running')
+    expect(result.title).toBe('Build feature')
+    expect(result.agents_active).toEqual(['pm', 'engineer'])
+    expect(result.blockers).toBeNull()
+  })
+
+  it('includes blockers when present', async () => {
+    const task = {
+      id: 'task-1',
+      title: 'Build feature',
+      status: 'blocked',
+      result_summary: null,
+      github_pr_url: null,
+      cost_tokens: null,
+      cost_usd: null,
+    }
+    const blockers = [
+      { content: 'Need API credentials' },
+      { content: 'Clarify requirements' },
+    ]
+    mockDb(task, null, blockers)
+
+    const result = await handleGetTaskStatus({ tenantId: 'tenant-1', task_id: 'task-1' })
+
+    expect(result.blockers).toEqual(['Need API credentials', 'Clarify requirements'])
+  })
+
+  it('enforces tenant isolation', async () => {
+    // Task exists but belongs to different tenant
+    mockDb(null) // returns empty because tenant_id filter doesn't match
+    await expect(
+      handleGetTaskStatus({ tenantId: 'tenant-other', task_id: 'task-1' })
+    ).rejects.toMatchObject({ code: -32002 })
+  })
+})

--- a/tests/mcp/reply-to-message.test.ts
+++ b/tests/mcp/reply-to-message.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('../../src/lib/fly-machines', () => ({
+  findMachineForProject: vi.fn(),
+  injectMessage: vi.fn(),
+}))
+
+import { handleReplyToMessage } from '../../src/app/api/mcp/tools/reply-to-message'
+import { createAdminClient } from '../../src/db/supabase'
+import { findMachineForProject, injectMessage } from '../../src/lib/fly-machines'
+
+function mockDb(outboxRow: any = null, taskRow: any = null) {
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'pm_outbox') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: outboxRow ? [outboxRow] : [] }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }
+      }
+      if (table === 'tasks') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: taskRow ? [taskRow] : [] }),
+          }),
+        }
+      }
+      return {}
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('handleReplyToMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws MCP error when message not found', async () => {
+    mockDb(null)
+    await expect(
+      handleReplyToMessage({
+        tenantId: 'tenant-1',
+        message_id: 'nonexistent',
+        response: 'Yes, proceed',
+      })
+    ).rejects.toMatchObject({
+      code: -32002,
+      message: expect.stringContaining('not found'),
+    })
+  })
+
+  it('throws MCP error when message does not require response', async () => {
+    mockDb({
+      id: 'msg-1',
+      tenant_id: 'tenant-1',
+      task_id: 'task-1',
+      requires_response: false,
+      response: null,
+    })
+    await expect(
+      handleReplyToMessage({
+        tenantId: 'tenant-1',
+        message_id: 'msg-1',
+        response: 'Yes, proceed',
+      })
+    ).rejects.toMatchObject({
+      code: -32004,
+    })
+  })
+
+  it('throws MCP error when already responded', async () => {
+    mockDb({
+      id: 'msg-1',
+      tenant_id: 'tenant-1',
+      task_id: 'task-1',
+      requires_response: true,
+      response: 'Already answered',
+    })
+    await expect(
+      handleReplyToMessage({
+        tenantId: 'tenant-1',
+        message_id: 'msg-1',
+        response: 'Duplicate response',
+      })
+    ).rejects.toMatchObject({
+      code: -32004,
+      message: expect.stringContaining('Already responded'),
+    })
+  })
+
+  it('stores response and injects message to running machine', async () => {
+    const outboxRow = {
+      id: 'msg-1',
+      tenant_id: 'tenant-1',
+      task_id: 'task-1',
+      requires_response: true,
+      response: null,
+    }
+    const taskRow = { id: 'task-1', project_id: 'proj-1' }
+    mockDb(outboxRow, taskRow)
+
+    const mockMachine = { id: 'machine-1', fly_app_name: 'cdt-app' }
+    vi.mocked(findMachineForProject).mockResolvedValue(mockMachine as any)
+    vi.mocked(injectMessage).mockResolvedValue(undefined)
+
+    const result = await handleReplyToMessage({
+      tenantId: 'tenant-1',
+      message_id: 'msg-1',
+      response: 'Yes, proceed with the implementation',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(injectMessage).toHaveBeenCalledWith(
+      mockMachine,
+      expect.objectContaining({
+        to: 'pm',
+        type: 'HUMAN_RESPONSE',
+        content: 'Yes, proceed with the implementation',
+      })
+    )
+  })
+
+  it('returns ok even when machine is unavailable (response queued)', async () => {
+    const outboxRow = {
+      id: 'msg-1',
+      tenant_id: 'tenant-1',
+      task_id: 'task-1',
+      requires_response: true,
+      response: null,
+    }
+    const taskRow = { id: 'task-1', project_id: 'proj-1' }
+    mockDb(outboxRow, taskRow)
+
+    vi.mocked(findMachineForProject).mockResolvedValue(null)
+
+    const result = await handleReplyToMessage({
+      tenantId: 'tenant-1',
+      message_id: 'msg-1',
+      response: 'Answer',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.note).toContain('queued')
+  })
+})

--- a/tests/mcp/submit-task.test.ts
+++ b/tests/mcp/submit-task.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('../../src/lib/fly-machines', () => ({
+  ensureMachineRunning: vi.fn(),
+}))
+
+import { handleSubmitTask } from '../../src/app/api/mcp/tools/submit-task'
+import { createAdminClient } from '../../src/db/supabase'
+import { ensureMachineRunning } from '../../src/lib/fly-machines'
+
+function mockDb(projectRows: any[] = [], insertResult: any = { id: 'task-1' }) {
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'projects') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockResolvedValue({ data: projectRows }),
+            }),
+          }),
+        }
+      }
+      if (table === 'tasks') {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockResolvedValue({ data: [insertResult], error: null }),
+          }),
+        }
+      }
+      return {}
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('handleSubmitTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('throws MCP error when project not found', async () => {
+    mockDb([])
+    await expect(
+      handleSubmitTask({
+        tenantId: 'tenant-1',
+        project: 'nonexistent',
+        title: 'Test task',
+        description: 'Test description',
+      })
+    ).rejects.toMatchObject({
+      code: -32002,
+      message: expect.stringContaining('not found'),
+    })
+  })
+
+  it('creates a task and returns task_id and status', async () => {
+    const project = { id: 'proj-1', name: 'my-project' }
+    mockDb([project], { id: 'task-abc', status: 'queued' })
+    vi.mocked(ensureMachineRunning).mockResolvedValue({ status: 'starting' } as any)
+
+    const result = await handleSubmitTask({
+      tenantId: 'tenant-1',
+      project: 'my-project',
+      title: 'Build feature',
+      description: 'Build a cool feature',
+    })
+
+    expect(result.task_id).toBe('task-abc')
+    expect(result.status).toMatch(/queued|running/)
+  })
+
+  it('uses default priority when not specified', async () => {
+    const project = { id: 'proj-1', name: 'my-project' }
+    const mockClient = mockDb([project], { id: 'task-1', status: 'queued' })
+    vi.mocked(ensureMachineRunning).mockResolvedValue({ status: 'starting' } as any)
+
+    await handleSubmitTask({
+      tenantId: 'tenant-1',
+      project: 'my-project',
+      title: 'Test',
+      description: 'Test',
+    })
+
+    // Verify insert was called
+    const taskCalls = mockClient.from.mock.calls.filter((c: any) => c[0] === 'tasks')
+    expect(taskCalls.length).toBeGreaterThan(0)
+  })
+
+  it('handles machine unavailability gracefully', async () => {
+    const project = { id: 'proj-1', name: 'my-project' }
+    mockDb([project], { id: 'task-1', status: 'queued' })
+    vi.mocked(ensureMachineRunning).mockRejectedValue(new Error('Fly API down'))
+
+    // Should still create the task but return queued status
+    const result = await handleSubmitTask({
+      tenantId: 'tenant-1',
+      project: 'my-project',
+      title: 'Test',
+      description: 'Test',
+    })
+
+    expect(result.task_id).toBe('task-1')
+    expect(result.status).toBe('queued')
+  })
+})

--- a/tests/mcp/tenant-isolation.test.ts
+++ b/tests/mcp/tenant-isolation.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+vi.mock('../../src/lib/fly-machines', () => ({
+  ensureMachineRunning: vi.fn(),
+  findMachineForProject: vi.fn(),
+  injectMessage: vi.fn(),
+}))
+
+import { handleSubmitTask } from '../../src/app/api/mcp/tools/submit-task'
+import { handleGetTaskStatus } from '../../src/app/api/mcp/tools/get-task-status'
+import { handleCheckMessages } from '../../src/app/api/mcp/tools/check-messages'
+import { handleReplyToMessage } from '../../src/app/api/mcp/tools/reply-to-message'
+import { createAdminClient } from '../../src/db/supabase'
+import { ensureMachineRunning } from '../../src/lib/fly-machines'
+
+const TENANT_A = 'tenant-aaa'
+const TENANT_B = 'tenant-bbb'
+
+function createChainableQuery(resolvedData: any) {
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === 'then') return (resolve: any) => resolve({ data: resolvedData })
+      return (..._args: any[]) => new Proxy({}, handler)
+    },
+  }
+  return new Proxy({}, handler)
+}
+
+/**
+ * Creates a mock Supabase client that enforces tenant_id filtering.
+ * Only returns data when the tenant_id in the .eq() call matches ownerTenantId.
+ */
+function mockDbWithTenantIsolation(ownerTenantId: string, data: Record<string, any[]>) {
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      const tableData = data[table] ?? []
+
+      // Track eq calls to check tenant_id filtering
+      let matchesTenant = false
+      const makeChain = (rows: any[]): any => {
+        const chain: any = {}
+        const methods = ['select', 'eq', 'in', 'is', 'order', 'limit']
+        for (const method of methods) {
+          chain[method] = vi.fn().mockImplementation((...args: any[]) => {
+            if (method === 'eq' && args[0] === 'tenant_id') {
+              matchesTenant = args[1] === ownerTenantId
+            }
+            return chain
+          })
+        }
+        // insert returns a chain that always resolves (no tenant filter on inserts)
+        chain.insert = vi.fn().mockImplementation((_row: any) => {
+          const insertChain = makeChain(rows)
+          // Force matchesTenant=true for insert results (inserts don't filter by tenant)
+          insertChain.then = (resolve: any) => resolve({ data: rows, error: null })
+          return insertChain
+        })
+        // update returns a chain with eq
+        chain.update = vi.fn().mockImplementation((_data: any) => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        }))
+        // When awaited, return data only if tenant matches
+        chain.then = (resolve: any) => {
+          resolve({ data: matchesTenant ? rows : [], error: null })
+        }
+        return chain
+      }
+
+      return makeChain(tableData)
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('Tenant Isolation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('submit_task', () => {
+    it('Tenant A can submit to their own project', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        projects: [{ id: 'proj-a', name: 'project-a' }],
+        tasks: [{ id: 'task-a1', status: 'queued' }],
+      })
+      vi.mocked(ensureMachineRunning).mockResolvedValue({ status: 'starting' } as any)
+
+      const result = await handleSubmitTask({
+        tenantId: TENANT_A,
+        project: 'project-a',
+        title: 'Test task',
+        description: 'Test',
+      })
+      expect(result.task_id).toBe('task-a1')
+    })
+
+    it('Tenant B cannot submit to Tenant A project', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        projects: [{ id: 'proj-a', name: 'project-a' }],
+      })
+
+      await expect(
+        handleSubmitTask({
+          tenantId: TENANT_B,
+          project: 'project-a',
+          title: 'Sneaky task',
+          description: 'Should fail',
+        })
+      ).rejects.toMatchObject({
+        code: -32002,
+        message: expect.stringContaining('not found'),
+      })
+    })
+  })
+
+  describe('get_task_status', () => {
+    it('Tenant A can view their own task', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        tasks: [{
+          id: 'task-a1',
+          project_id: 'proj-a',
+          title: 'My task',
+          status: 'running',
+          result_summary: null,
+          github_pr_url: null,
+          cost_tokens: null,
+          cost_usd: null,
+        }],
+        machines: [],
+        pm_outbox: [],
+      })
+
+      const result = await handleGetTaskStatus({ tenantId: TENANT_A, task_id: 'task-a1' })
+      expect(result.status).toBe('running')
+      expect(result.title).toBe('My task')
+    })
+
+    it('Tenant B cannot view Tenant A task', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        tasks: [{
+          id: 'task-a1',
+          title: 'Secret task',
+          status: 'running',
+        }],
+      })
+
+      await expect(
+        handleGetTaskStatus({ tenantId: TENANT_B, task_id: 'task-a1' })
+      ).rejects.toMatchObject({
+        code: -32002,
+        message: expect.stringContaining('not found'),
+      })
+    })
+  })
+
+  describe('check_messages', () => {
+    it('Tenant A sees their own messages', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        pm_outbox: [{
+          id: 'msg-a1',
+          task_id: 'task-a1',
+          type: 'question',
+          content: 'Need input',
+          requires_response: true,
+          response: null,
+          created_at: '2026-03-10T00:00:00Z',
+          read_at: null,
+          tasks: { projects: { name: 'project-a' } },
+        }],
+      })
+
+      const result = await handleCheckMessages({ tenantId: TENANT_A })
+      expect(result.messages).toHaveLength(1)
+    })
+
+    it('Tenant B sees empty messages for Tenant A data', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        pm_outbox: [{
+          id: 'msg-a1',
+          task_id: 'task-a1',
+          type: 'question',
+          content: 'Secret message',
+        }],
+      })
+
+      const result = await handleCheckMessages({ tenantId: TENANT_B })
+      expect(result.messages).toEqual([])
+    })
+  })
+
+  describe('reply_to_message', () => {
+    it('Tenant B cannot reply to Tenant A message', async () => {
+      mockDbWithTenantIsolation(TENANT_A, {
+        pm_outbox: [{
+          id: 'msg-a1',
+          tenant_id: TENANT_A,
+          task_id: 'task-a1',
+          requires_response: true,
+          response: null,
+        }],
+      })
+
+      await expect(
+        handleReplyToMessage({
+          tenantId: TENANT_B,
+          message_id: 'msg-a1',
+          response: 'Unauthorized reply',
+        })
+      ).rejects.toMatchObject({
+        code: -32002,
+        message: expect.stringContaining('not found'),
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements MCP server as Next.js API route (`/api/mcp`) using streamable HTTP transport (stateless mode for Vercel serverless)
- 4 MCP tools: `submit_task`, `get_task_status`, `check_messages`, `reply_to_message`
- 3 MCP resources: `project://{id}/overview`, `project://{id}/activity`, `project://{id}/tasks`
- CDT API key authentication with bcrypt verification and prefix-based fast lookup
- Fly Machine helpers stubbed with TODO for #18 (ensureMachineRunning, findMachineForProject, injectMessage)
- In-memory rate limiting foundation (headers only, not enforced in Phase 1)

## Test plan

- [x] 37 tests across 7 test files, all passing
- [x] Auth tests: valid/invalid keys, missing Bearer prefix, prefix filtering, last_used update (7 tests)
- [x] Tool unit tests: submit-task (4), get-task-status (4), check-messages (7), reply-to-message (5)
- [x] E2E flow test: submit -> check -> reply lifecycle, machine-unavailable fallback, reply-when-stopped (3 tests)
- [x] Tenant isolation: cross-tenant access blocked for all 4 tools (7 tests)
- [x] No regressions: 246 total tests passing (baseline was 209)
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)