### PR TITLE
Add broker cloud mode (CC_MODE=cloud)

### DIFF
--- a/broker/lib/cloudAgent.js
+++ b/broker/lib/cloudAgent.js
@@ -1,0 +1,84 @@
+import { spawn } from 'child_process'
+import { createInterface } from 'readline'
+
+/**
+ * Spawns a Pi agent in RPC mode (stdin/stdout JSONL pipes).
+ *
+ * @param {string} role - Agent role (e.g., 'pm', 'architect', 'engineer')
+ * @param {object} config
+ * @param {string} config.systemPrompt - Path to the agent's system prompt file
+ * @param {string} config.workDir - Working directory for the agent
+ * @param {object} config.env - Additional environment variables
+ * @param {function} [config.onEvent] - Callback for parsed JSONL events from stdout
+ * @param {function} [config.onExit] - Callback when the process exits
+ * @returns {object} Agent handle with send/prompt/steer/abort/kill methods
+ */
+export function spawnCloudAgent(role, config) {
+  const { systemPrompt, workDir, env = {}, onEvent, onExit } = config
+
+  const args = ['--mode', 'rpc', '--system-prompt', systemPrompt]
+
+  const proc = spawn('pi', args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: { ...process.env, ...env },
+    cwd: workDir
+  })
+
+  // JSONL reader on stdout
+  const reader = createInterface({ input: proc.stdout })
+  reader.on('line', (line) => {
+    try {
+      const event = JSON.parse(line)
+      if (onEvent) onEvent(event)
+    } catch {
+      // Non-JSON output — log but don't crash
+      console.warn(`[CloudAgent:${role}] Non-JSON stdout: ${line}`)
+    }
+  })
+
+  // Log stderr
+  proc.stderr.on('data', (data) => {
+    console.error(`[CloudAgent:${role}:stderr] ${data.toString().trim()}`)
+  })
+
+  proc.on('exit', (code, signal) => {
+    if (onExit) onExit(code, signal)
+  })
+
+  const agent = {
+    proc,
+    role,
+
+    /** Send raw JSONL command via stdin */
+    send(command) {
+      proc.stdin.write(JSON.stringify(command) + '\n')
+    },
+
+    /** Send a prompt to the agent (uses 'message' field per Pi RPC protocol) */
+    prompt(text) {
+      agent.send({ type: 'prompt', message: text })
+    },
+
+    /** Steer the agent with additional context */
+    steer(text) {
+      agent.send({ type: 'steer', message: text })
+    },
+
+    /** Send a follow-up message */
+    followUp(text) {
+      agent.send({ type: 'follow_up', message: text })
+    },
+
+    /** Abort the current operation */
+    abort() {
+      agent.send({ type: 'abort' })
+    },
+
+    /** Kill the process */
+    kill() {
+      proc.kill('SIGTERM')
+    }
+  }
+
+  return agent
+}

--- a/broker/lib/cloudMode.js
+++ b/broker/lib/cloudMode.js
@@ -1,0 +1,6 @@
+export { spawnCloudAgent } from './cloudAgent.js'
+export { createHealthEndpoint } from './healthEndpoint.js'
+export { createInjectEndpoint } from './injectEndpoint.js'
+export { TaskManager } from './taskManager.js'
+export { OutboxPoster } from './outboxPoster.js'
+export { GracefulShutdown } from './gracefulShutdown.js'

--- a/broker/lib/gracefulShutdown.js
+++ b/broker/lib/gracefulShutdown.js
@@ -1,0 +1,71 @@
+/**
+ * Handles graceful SIGTERM shutdown in cloud mode.
+ * Aborts agents, flushes state to Supabase, closes SQLite.
+ */
+export class GracefulShutdown {
+  constructor({ supabase, db, agents, machineId, currentTask, heartbeatInterval, taskTimeout }) {
+    this.supabase = supabase
+    this.db = db
+    this.agents = agents
+    this.machineId = machineId
+    this.currentTask = currentTask
+    this.heartbeatInterval = heartbeatInterval
+    this.taskTimeout = taskTimeout
+    this._executed = false
+  }
+
+  async execute() {
+    if (this._executed) return
+    this._executed = true
+
+    const shutdownStart = Date.now()
+    console.log('[Cloud] Graceful shutdown starting...')
+
+    try {
+      // 1. Stop timers
+      if (this.heartbeatInterval) clearInterval(this.heartbeatInterval)
+      if (this.taskTimeout) clearTimeout(this.taskTimeout)
+
+      // 2. Abort all agents
+      for (const [role, agent] of this.agents) {
+        console.log(`[Cloud] Aborting agent: ${role}`)
+        agent.abort()
+      }
+
+      // 3. Wait briefly for agents to flush (up to 3 seconds)
+      await Promise.race([
+        Promise.all([...this.agents.values()].map(a =>
+          new Promise(resolve => a.proc.on('exit', resolve))
+        )),
+        new Promise(resolve => setTimeout(resolve, 3000))
+      ])
+
+      // 4. Update task status if in-progress
+      if (this.currentTask?.status === 'running') {
+        await this.supabase
+          .from('tasks')
+          .update({
+            status: 'queued',
+            error: 'Machine stopped during execution'
+          })
+          .eq('id', this.currentTask.id)
+      }
+
+      // 5. Update machine status
+      await this.supabase
+        .from('machines')
+        .update({
+          status: 'stopped',
+          updated_at: new Date().toISOString()
+        })
+        .eq('id', this.machineId)
+
+      // 6. Close SQLite
+      this.db.close()
+
+      console.log(`[Cloud] Shutdown complete in ${Date.now() - shutdownStart}ms`)
+    } catch (err) {
+      console.error('[Cloud] Shutdown error:', err)
+    }
+  }
+}

--- a/broker/lib/healthEndpoint.js
+++ b/broker/lib/healthEndpoint.js
@@ -1,0 +1,32 @@
+/**
+ * Creates a request handler for GET /health.
+ *
+ * @param {function} getState - Returns current broker state
+ * @returns {function} HTTP request handler
+ */
+export function createHealthEndpoint(getState) {
+  return function handleHealth(req, res) {
+    const state = getState()
+    const statusCode = state.healthy ? 200 : 503
+
+    const body = JSON.stringify({
+      status: state.healthy ? 'healthy' : 'unhealthy',
+      uptime: process.uptime(),
+      mode: 'cloud',
+      agents: state.agents.map(a => ({
+        role: a.role,
+        status: a.status,
+        pid: a.pid
+      })),
+      task: state.currentTask ? {
+        id: state.currentTask.id,
+        status: state.currentTask.status,
+        started_at: state.currentTask.startedAt
+      } : null,
+      memory: process.memoryUsage()
+    })
+
+    res.writeHead(statusCode, { 'Content-Type': 'application/json' })
+    res.end(body)
+  }
+}

--- a/broker/lib/injectEndpoint.js
+++ b/broker/lib/injectEndpoint.js
@@ -1,0 +1,43 @@
+/**
+ * Creates a request handler for POST /api/inject-message.
+ *
+ * @param {object} opts
+ * @param {object} opts.db - SQLite database instance
+ * @param {string} opts.machineJwt - Expected JWT for authentication
+ * @param {string} opts.sessionId - Current broker session ID
+ * @param {function} opts.deliverMessage - Callback to deliver message to agent (role, content)
+ * @returns {function} HTTP request handler
+ */
+export function createInjectEndpoint({ db, machineJwt, sessionId, deliverMessage }) {
+  return function handleInject(req, res) {
+    // Validate JWT
+    const authHeader = req.headers.authorization || req.headers.Authorization
+    const token = authHeader?.replace('Bearer ', '')
+    if (!token || token !== machineJwt) {
+      res.writeHead(401, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Invalid token' }))
+      return
+    }
+
+    const { to, type, content } = req.body || {}
+    if (!to || !type || !content) {
+      res.writeHead(400, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Missing required fields: to, type, content' }))
+      return
+    }
+
+    // Write to SQLite messages table (same schema as local mode)
+    const stmt = db.prepare(
+      'INSERT INTO messages (session_id, from_agent, to_agent, message_type, content) VALUES (?, ?, ?, ?, ?)'
+    )
+    const result = stmt.run(sessionId, 'human', to, type, content)
+
+    // Deliver to the target agent via broker
+    if (deliverMessage) {
+      deliverMessage(to, content)
+    }
+
+    res.writeHead(200, { 'Content-Type': 'application/json' })
+    res.end(JSON.stringify({ ok: true, messageId: result.lastInsertRowid }))
+  }
+}

--- a/broker/lib/outboxPoster.js
+++ b/broker/lib/outboxPoster.js
@@ -1,0 +1,43 @@
+/**
+ * Bridges PM-to-human messages from local SQLite to Supabase pm_outbox.
+ * Detects messages where to_agent='human' and posts them to the cloud outbox.
+ */
+export class OutboxPoster {
+  constructor({ supabase, taskId, tenantId }) {
+    this.supabase = supabase
+    this.taskId = taskId
+    this.tenantId = tenantId
+  }
+
+  /** Types that require a human response */
+  static RESPONSE_TYPES = new Set(['HUMAN_QUESTION', 'APPROVAL_REQUEST'])
+
+  /**
+   * Check if a message should be posted to the outbox.
+   * Only messages directed at 'human' are outbox-bound.
+   */
+  shouldPost(message) {
+    return message.to_agent === 'human'
+  }
+
+  /**
+   * Post a message to the Supabase pm_outbox table.
+   */
+  async post(message) {
+    const requiresResponse = OutboxPoster.RESPONSE_TYPES.has(message.message_type)
+
+    const { error } = await this.supabase
+      .from('pm_outbox')
+      .insert({
+        task_id: this.taskId,
+        tenant_id: this.tenantId,
+        type: message.message_type,
+        content: message.content,
+        requires_response: requiresResponse
+      })
+
+    if (error) {
+      console.error(`[OutboxPoster] Failed to post to outbox:`, error.message)
+    }
+  }
+}

--- a/broker/lib/taskManager.js
+++ b/broker/lib/taskManager.js
@@ -1,0 +1,96 @@
+/**
+ * Manages task lifecycle in cloud mode — loading from Supabase,
+ * assigning to PM via SQLite, completing, failing, and checking the queue.
+ */
+export class TaskManager {
+  constructor({ supabase, db, sessionId }) {
+    this.supabase = supabase
+    this.db = db
+    this.sessionId = sessionId
+    this.currentProjectId = null
+  }
+
+  /**
+   * Load a task from Supabase by ID and mark it as running.
+   */
+  async loadTask(taskId) {
+    const { data: task, error } = await this.supabase
+      .from('tasks')
+      .select('*, projects(*)')
+      .eq('id', taskId)
+      .single()
+
+    if (error || !task) {
+      throw new Error(`Task ${taskId} not found: ${error?.message || 'no data'}`)
+    }
+
+    this.currentProjectId = task.project_id || task.projectId
+
+    // Mark task as running
+    await this.supabase
+      .from('tasks')
+      .update({ status: 'running', started_at: new Date().toISOString() })
+      .eq('id', taskId)
+
+    return task
+  }
+
+  /**
+   * Mark a task as completed in Supabase.
+   */
+  async completeTask(taskId, result) {
+    await this.supabase
+      .from('tasks')
+      .update({
+        status: 'completed',
+        completed_at: new Date().toISOString(),
+        result_summary: result.summary,
+        github_pr_url: result.prUrl,
+        cost_usd: result.costUsd
+      })
+      .eq('id', taskId)
+  }
+
+  /**
+   * Mark a task as failed in Supabase.
+   */
+  async failTask(taskId, errorMessage) {
+    await this.supabase
+      .from('tasks')
+      .update({
+        status: 'failed',
+        completed_at: new Date().toISOString(),
+        error: errorMessage
+      })
+      .eq('id', taskId)
+  }
+
+  /**
+   * Write a TASK_ASSIGNMENT message to SQLite for the PM agent.
+   */
+  assignTaskToPm(task) {
+    const content = `New task assigned: "${task.title}"\n\nDescription: ${task.description || 'N/A'}\n\nProject: ${task.projects?.name || 'unknown'}\nRepo: ${task.projects?.repo_url || 'N/A'}\nPriority: ${task.priority || 'normal'}`
+
+    this.db.prepare(
+      'INSERT INTO messages (session_id, from_agent, to_agent, message_type, content) VALUES (?, ?, ?, ?, ?)'
+    ).run(this.sessionId, 'system', 'pm', 'TASK_ASSIGNMENT', content)
+  }
+
+  /**
+   * Check Supabase for the next queued task for the current project.
+   */
+  async checkForQueuedTasks() {
+    if (!this.currentProjectId) return null
+
+    const { data: nextTask } = await this.supabase
+      .from('tasks')
+      .select('*')
+      .eq('project_id', this.currentProjectId)
+      .eq('status', 'queued')
+      .order('submitted_at', { ascending: true })
+      .limit(1)
+      .single()
+
+    return nextTask || null
+  }
+}

--- a/broker/server.js
+++ b/broker/server.js
@@ -1,4 +1,3 @@
-import { Server } from 'socket.io'
 import { createServer } from 'http'
 import { DatabaseSync } from 'node:sqlite'
 import { mkdirSync, readdirSync, readFileSync, statSync, existsSync, writeFileSync, rmSync, unlinkSync } from 'fs'
@@ -11,9 +10,16 @@ import { homedir } from 'os'
 import { getNextInstanceId } from './lib/getNextInstanceId.js'
 import { detectWorktrees } from './lib/worktreeDetection.js'
 
+// ============================================================================
+// MODE DETECTION
+// ============================================================================
+
+const CC_MODE = process.env.CC_MODE || 'local'
+const isCloudMode = CC_MODE === 'cloud'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ORCHESTRATOR_DIR = join(__dirname, '..')
-const DATA_DIR = join(ORCHESTRATOR_DIR, 'data')
+const DATA_DIR = isCloudMode ? (process.env.DATA_DIR || '/data') : join(ORCHESTRATOR_DIR, 'data')
 const TOOLS_DIR = join(ORCHESTRATOR_DIR, 'tools')
 const AGENTS_DIR = join(ORCHESTRATOR_DIR, 'agents')
 const PLUGINS_DIR = join(ORCHESTRATOR_DIR, 'plugins')
@@ -22,7 +28,9 @@ const TEMP_DIR = '/tmp/cc-dev-team'
 
 // Ensure data directory exists
 mkdirSync(DATA_DIR, { recursive: true })
-mkdirSync(UPLOADS_DIR, { recursive: true })
+if (!isCloudMode) {
+  mkdirSync(UPLOADS_DIR, { recursive: true })
+}
 mkdirSync(TEMP_DIR, { recursive: true })
 
 // Initialize SQLite database for message persistence
@@ -46,12 +54,18 @@ db.exec(`
 `)
 
 const server = createServer()
-const io = new Server(server, {
-  cors: {
-    origin: '*',
-    methods: ['GET', 'POST']
-  }
-})
+
+// Socket.io is only used in local mode (dashboard communication)
+let io
+if (!isCloudMode) {
+  const { Server } = await import('socket.io')
+  io = new Server(server, {
+    cors: {
+      origin: '*',
+      methods: ['GET', 'POST']
+    }
+  })
+}
 
 // ============================================================================
 // SESSION MANAGEMENT
@@ -285,6 +299,9 @@ function forceKillAgent(session, role) {
 // ============================================================================
 // SOCKET.IO CONNECTION HANDLING
 // ============================================================================
+
+// Socket.io connection handling is local mode only
+if (!isCloudMode) {
 
 io.on('connection', (socket) => {
   const agentRole = socket.handshake.query.agent
@@ -1092,16 +1109,243 @@ io.on('connection', (socket) => {
   })
 })
 
+} // end if (!isCloudMode) — socket.io block
+
 // ============================================================================
 // SERVER STARTUP
 // ============================================================================
 
-const PORT = process.env.BROKER_PORT || 3100
+const PORT = process.env.BROKER_PORT || process.env.PORT || 3100
 
-server.listen(PORT, () => {
-  const dbPath = join(DATA_DIR, 'messages.db')
-  const pad = (str, len) => str + ' '.repeat(Math.max(0, len - str.length))
-  console.log(`
+if (isCloudMode) {
+  // ==========================================================================
+  // CLOUD MODE STARTUP
+  // ==========================================================================
+
+  const { spawnCloudAgent, createHealthEndpoint, createInjectEndpoint, TaskManager, OutboxPoster, GracefulShutdown } = await import('./lib/cloudMode.js')
+  const { createClient } = await import('@supabase/supabase-js')
+
+  // Validate required env vars
+  const SUPABASE_URL = process.env.SUPABASE_URL
+  const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const TASK_ID = process.env.TASK_ID
+  const MACHINE_JWT = process.env.MACHINE_JWT
+  const MACHINE_ID = process.env.MACHINE_ID || process.env.FLY_MACHINE_ID
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+    console.error('[Cloud] SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required')
+    process.exit(1)
+  }
+  if (!TASK_ID) {
+    console.error('[Cloud] TASK_ID is required')
+    process.exit(1)
+  }
+
+  const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY)
+
+  // Cloud session — single session per container
+  const cloudSessionId = randomUUID()
+  const cloudAgents = new Map() // role -> cloud agent handle
+
+  // Task manager
+  const taskManager = new TaskManager({ supabase, db, sessionId: cloudSessionId })
+
+  // Load task from Supabase
+  let currentTask
+  try {
+    currentTask = await taskManager.loadTask(TASK_ID)
+    console.log(`[Cloud] Loaded task: "${currentTask.title}" (${TASK_ID})`)
+  } catch (err) {
+    console.error(`[Cloud] Failed to load task:`, err.message)
+    process.exit(1)
+  }
+
+  // Outbox poster (bridges PM→human messages to Supabase)
+  const outboxPoster = new OutboxPoster({
+    supabase,
+    taskId: TASK_ID,
+    tenantId: currentTask.tenant_id || currentTask.tenantId
+  })
+
+  // Function to deliver messages to cloud agents via Pi RPC
+  function deliverMessageToAgent(to, content) {
+    const agent = cloudAgents.get(to)
+    if (agent) {
+      agent.steer(content)
+    }
+  }
+
+  // HTTP request router (health + inject endpoints)
+  const healthHandler = createHealthEndpoint(() => ({
+    healthy: cloudAgents.has('pm'),
+    agents: [...cloudAgents.entries()].map(([role, a]) => ({
+      role,
+      status: 'active',
+      pid: a.proc.pid
+    })),
+    currentTask: currentTask ? {
+      id: currentTask.id,
+      status: currentTask.status || 'running',
+      startedAt: currentTask.started_at || currentTask.startedAt
+    } : null
+  }))
+
+  const injectHandler = createInjectEndpoint({
+    db,
+    machineJwt: MACHINE_JWT,
+    sessionId: cloudSessionId,
+    deliverMessage: deliverMessageToAgent
+  })
+
+  server.on('request', (req, res) => {
+    if (req.method === 'GET' && req.url === '/health') {
+      healthHandler(req, res)
+    } else if (req.method === 'POST' && req.url === '/api/inject-message') {
+      let body = ''
+      req.on('data', chunk => body += chunk)
+      req.on('end', () => {
+        try {
+          req.body = JSON.parse(body)
+        } catch {
+          res.writeHead(400, { 'Content-Type': 'application/json' })
+          res.end(JSON.stringify({ error: 'Invalid JSON' }))
+          return
+        }
+        injectHandler(req, res)
+      })
+    } else {
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'Not found' }))
+    }
+  })
+
+  // Heartbeat — update machines.updated_at every 60s
+  let heartbeatInterval
+  if (MACHINE_ID) {
+    heartbeatInterval = setInterval(async () => {
+      try {
+        await supabase
+          .from('machines')
+          .update({ updated_at: new Date().toISOString() })
+          .eq('id', MACHINE_ID)
+      } catch (err) {
+        console.warn('[Cloud] Heartbeat failed:', err.message)
+      }
+    }, 60_000)
+  }
+
+  // Max task duration timer
+  const MAX_TASK_DURATION_MS = parseInt(process.env.MAX_TASK_DURATION_MS || String(2 * 60 * 60 * 1000))
+  const taskTimeout = setTimeout(async () => {
+    console.warn(`[Cloud] Task ${TASK_ID} exceeded max duration (${MAX_TASK_DURATION_MS}ms). Aborting.`)
+
+    for (const [, agent] of cloudAgents) {
+      agent.abort()
+    }
+
+    await taskManager.failTask(TASK_ID, 'Task exceeded maximum duration')
+
+    const nextTask = await taskManager.checkForQueuedTasks()
+    if (nextTask) {
+      console.log(`[Cloud] Next queued task: ${nextTask.id}`)
+    } else {
+      console.log('[Cloud] No queued tasks. Going idle.')
+    }
+  }, MAX_TASK_DURATION_MS)
+
+  // Graceful shutdown
+  const gracefulShutdown = new GracefulShutdown({
+    supabase,
+    db,
+    agents: cloudAgents,
+    machineId: MACHINE_ID,
+    currentTask,
+    heartbeatInterval,
+    taskTimeout
+  })
+
+  process.on('SIGTERM', () => gracefulShutdown.execute().then(() => process.exit(0)))
+  process.on('SIGINT', () => gracefulShutdown.execute().then(() => process.exit(0)))
+
+  // Intercept SQLite writes to detect outbox-bound messages
+  // Poll for new messages to 'human' periodically
+  const outboxCheckInterval = setInterval(() => {
+    try {
+      const humanMessages = db.prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND to_agent = ? AND read = 0'
+      ).all(cloudSessionId, 'human')
+
+      for (const msg of humanMessages) {
+        if (outboxPoster.shouldPost(msg)) {
+          outboxPoster.post(msg)
+          db.prepare('UPDATE messages SET read = 1 WHERE id = ?').run(msg.id)
+        }
+      }
+    } catch { /* ignore transient SQLite errors */ }
+  }, 5_000)
+
+  // Spawn PM agent (the only agent spawned initially in cloud mode)
+  function getAgentConfig(role) {
+    const baseRole = role.match(/^(.+)-\d+$/)?.[1] || role
+    return {
+      systemPrompt: join(AGENTS_DIR, baseRole, 'system-prompt.md'),
+      workDir: process.env.PROJECT_WORK_DIR || DATA_DIR,
+      env: {
+        AGENT_ROLE: role,
+        SESSION_ID: cloudSessionId,
+        BROKER_SESSION_ID: cloudSessionId,
+        ORCHESTRATOR_DIR,
+        GITHUB_TOKEN: process.env.GITHUB_TOKEN || '',
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || ''
+      },
+      onEvent: (event) => {
+        // Track agent status from RPC events
+        if (event.type === 'error') {
+          console.error(`[Cloud:${role}] Error:`, event.message || event)
+        }
+      },
+      onExit: (code, signal) => {
+        console.log(`[Cloud] Agent ${role} exited (code=${code}, signal=${signal})`)
+        cloudAgents.delete(role)
+      }
+    }
+  }
+
+  const pmAgent = spawnCloudAgent('pm', getAgentConfig('pm'))
+  cloudAgents.set('pm', pmAgent)
+  console.log('[Cloud] PM agent spawned via Pi RPC')
+
+  // Assign the loaded task to PM
+  taskManager.assignTaskToPm(currentTask)
+  // Deliver via broker-delivered messaging (steer the PM directly)
+  const taskContent = `New task assigned: "${currentTask.title}"\n\nDescription: ${currentTask.description || 'N/A'}`
+  pmAgent.prompt(taskContent)
+  console.log('[Cloud] Task assigned to PM')
+
+  // Start HTTP server
+  server.listen(PORT, () => {
+    const pad = (str, len) => str + ' '.repeat(Math.max(0, len - str.length))
+    console.log(`
+╔════════════════════════════════════════════════════════════╗
+║              CC DEV TEAM - CLOUD BROKER                    ║
+╠════════════════════════════════════════════════════════════╣
+║  ${pad('Status: RUNNING', 58)}║
+║  ${pad('Mode: CLOUD', 58)}║
+║  ${pad('Port: ' + PORT, 58)}║
+║  ${pad('Task: ' + TASK_ID, 58)}║
+╚════════════════════════════════════════════════════════════╝
+    `)
+  })
+
+} else {
+  // ==========================================================================
+  // LOCAL MODE STARTUP (unchanged)
+  // ==========================================================================
+
+  server.listen(PORT, () => {
+    const dbPath = join(DATA_DIR, 'messages.db')
+    const pad = (str, len) => str + ' '.repeat(Math.max(0, len - str.length))
+    console.log(`
 ╔════════════════════════════════════════════════════════════╗
 ║                CC DEV TEAM - MESSAGE BROKER                ║
 ╠════════════════════════════════════════════════════════════╣
@@ -1112,44 +1356,45 @@ server.listen(PORT, () => {
 ╚════════════════════════════════════════════════════════════╝
 
 Waiting for connections...
-  `)
-})
+    `)
+  })
 
-// Graceful shutdown — handle both SIGINT (Ctrl+C) and SIGTERM (from parent shell/process manager)
-let shuttingDown = false
-function shutdown() {
-  if (shuttingDown) return
-  shuttingDown = true
+  // Graceful shutdown — handle both SIGINT (Ctrl+C) and SIGTERM (from parent shell/process manager)
+  let shuttingDown = false
+  function shutdown() {
+    if (shuttingDown) return
+    shuttingDown = true
 
-  console.log('\n[Broker] Shutting down...')
+    console.log('\n[Broker] Shutting down...')
 
-  // Kill poller processes first (they hold FIFOs open and block on read)
-  try {
-    const entries = readdirSync(TEMP_DIR)
-    for (const entry of entries) {
-      if (entry.startsWith('poller-') && entry.endsWith('.lock')) {
-        try {
-          const pid = parseInt(readFileSync(join(TEMP_DIR, entry), 'utf8').trim(), 10)
-          if (pid) process.kill(pid, 'SIGTERM')
-        } catch { /* ignore — process already dead or lock corrupted */ }
+    // Kill poller processes first (they hold FIFOs open and block on read)
+    try {
+      const entries = readdirSync(TEMP_DIR)
+      for (const entry of entries) {
+        if (entry.startsWith('poller-') && entry.endsWith('.lock')) {
+          try {
+            const pid = parseInt(readFileSync(join(TEMP_DIR, entry), 'utf8').trim(), 10)
+            if (pid) process.kill(pid, 'SIGTERM')
+          } catch { /* ignore — process already dead or lock corrupted */ }
+        }
+      }
+    } catch { /* TEMP_DIR may not exist */ }
+
+    // Kill all agent processes in all sessions
+    for (const [sessionId, session] of sessions) {
+      for (const [role, proc] of session.processes) {
+        console.log(`[Broker] Killing ${role} in session ${sessionId}`)
+        proc.kill('SIGTERM')
       }
     }
-  } catch { /* TEMP_DIR may not exist */ }
 
-  // Kill all agent processes in all sessions
-  for (const [sessionId, session] of sessions) {
-    for (const [role, proc] of session.processes) {
-      console.log(`[Broker] Killing ${role} in session ${sessionId}`)
-      proc.kill('SIGTERM')
-    }
+    // Clean up all temp files (FIFOs and lock files)
+    try { rmSync(TEMP_DIR, { recursive: true, force: true }) } catch { /* ignore */ }
+
+    db.close()
+    process.exit(0)
   }
 
-  // Clean up all temp files (FIFOs and lock files)
-  try { rmSync(TEMP_DIR, { recursive: true, force: true }) } catch { /* ignore */ }
-
-  db.close()
-  process.exit(0)
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
 }
-
-process.on('SIGINT', shutdown)
-process.on('SIGTERM', shutdown)

--- a/tests/unit/broker/cloudAgent.test.js
+++ b/tests/unit/broker/cloudAgent.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { spawn } from 'child_process'
+import { spawnCloudAgent } from '../../../broker/lib/cloudAgent.js'
+
+// Mock child_process
+vi.mock('child_process', async () => {
+  const { EventEmitter } = await import('events')
+  const { PassThrough } = await import('stream')
+
+  function createMockProc() {
+    const proc = new EventEmitter()
+    proc.stdin = new PassThrough()
+    proc.stdout = new PassThrough()
+    proc.stderr = new PassThrough()
+    proc.pid = 12345
+    proc.kill = vi.fn()
+    return proc
+  }
+
+  return {
+    spawn: vi.fn(() => createMockProc())
+  }
+})
+
+describe('cloudAgent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('spawnCloudAgent', () => {
+    it('spawns pi with --mode rpc and correct args', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: { GITHUB_TOKEN: 'test-token' }
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+
+      expect(spawn).toHaveBeenCalledWith(
+        'pi',
+        expect.arrayContaining(['--mode', 'rpc', '--system-prompt', '/app/agents/pm/SYSTEM.md']),
+        expect.objectContaining({
+          stdio: ['pipe', 'pipe', 'pipe'],
+          cwd: '/data/test-project'
+        })
+      )
+      expect(agent).toHaveProperty('proc')
+      expect(agent).toHaveProperty('send')
+      expect(agent).toHaveProperty('prompt')
+      expect(agent).toHaveProperty('steer')
+      expect(agent).toHaveProperty('abort')
+      expect(agent).toHaveProperty('kill')
+    })
+
+    it('uses message field not text when sending prompt', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {}
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+      const writeSpy = vi.spyOn(agent.proc.stdin, 'write')
+
+      agent.prompt('Hello PM')
+
+      expect(writeSpy).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'prompt', message: 'Hello PM' }) + '\n'
+      )
+    })
+
+    it('uses message field for steer commands', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {}
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+      const writeSpy = vi.spyOn(agent.proc.stdin, 'write')
+
+      agent.steer('New context')
+
+      expect(writeSpy).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'steer', message: 'New context' }) + '\n'
+      )
+    })
+
+    it('abort sends abort command via stdin', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {}
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+      const writeSpy = vi.spyOn(agent.proc.stdin, 'write')
+
+      agent.abort()
+
+      expect(writeSpy).toHaveBeenCalledWith(
+        JSON.stringify({ type: 'abort' }) + '\n'
+      )
+    })
+
+    it('kill sends SIGTERM to process', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {}
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+      agent.kill()
+
+      expect(agent.proc.kill).toHaveBeenCalledWith('SIGTERM')
+    })
+
+    it('parses JSONL events from stdout and calls onEvent', () => {
+      const events = []
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {},
+        onEvent: (event) => events.push(event)
+      }
+
+      const agent = spawnCloudAgent('pm', config)
+
+      // Simulate Pi sending JSONL events
+      agent.proc.stdout.push(JSON.stringify({ type: 'agent_start', agent: 'pm' }) + '\n')
+      agent.proc.stdout.push(JSON.stringify({ type: 'tool_execution_start', tool: 'Read' }) + '\n')
+
+      // Give readline time to process
+      return new Promise(resolve => {
+        setTimeout(() => {
+          expect(events).toHaveLength(2)
+          expect(events[0]).toEqual({ type: 'agent_start', agent: 'pm' })
+          expect(events[1]).toEqual({ type: 'tool_execution_start', tool: 'Read' })
+          resolve()
+        }, 50)
+      })
+    })
+
+    it('passes env vars through to child process', () => {
+      const config = {
+        systemPrompt: '/app/agents/pm/SYSTEM.md',
+        workDir: '/data/test-project',
+        env: {
+          GITHUB_TOKEN: 'gh-token',
+          ANTHROPIC_API_KEY: 'anthropic-key'
+        }
+      }
+
+      spawnCloudAgent('pm', config)
+
+      const spawnCall = spawn.mock.calls[0]
+      const spawnEnv = spawnCall[2].env
+      expect(spawnEnv.GITHUB_TOKEN).toBe('gh-token')
+      expect(spawnEnv.ANTHROPIC_API_KEY).toBe('anthropic-key')
+    })
+  })
+})

--- a/tests/unit/broker/gracefulShutdown.test.js
+++ b/tests/unit/broker/gracefulShutdown.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { GracefulShutdown } from '../../../broker/lib/gracefulShutdown.js'
+
+describe('GracefulShutdown', () => {
+  let mockSupabase
+  let mockDb
+  let mockAgents
+  let shutdown
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn(() => mockSupabase),
+      update: vi.fn(() => mockSupabase),
+      eq: vi.fn(() => ({ error: null }))
+    }
+
+    mockDb = { close: vi.fn() }
+
+    const mockProc = {
+      kill: vi.fn(),
+      on: vi.fn((event, cb) => { if (event === 'exit') setTimeout(cb, 10) })
+    }
+
+    mockAgents = new Map([
+      ['pm', { proc: mockProc, abort: vi.fn() }]
+    ])
+
+    shutdown = new GracefulShutdown({
+      supabase: mockSupabase,
+      db: mockDb,
+      agents: mockAgents,
+      machineId: 'fly-machine-1',
+      currentTask: { id: 'task-abc', status: 'running' },
+      heartbeatInterval: null,
+      taskTimeout: null
+    })
+  })
+
+  it('aborts all agents on shutdown', async () => {
+    await shutdown.execute()
+
+    const agent = mockAgents.get('pm')
+    expect(agent.abort).toHaveBeenCalled()
+  })
+
+  it('updates task status to queued if running', async () => {
+    await shutdown.execute()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+    expect(mockSupabase.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'queued', error: expect.any(String) })
+    )
+  })
+
+  it('updates machine status to stopped', async () => {
+    await shutdown.execute()
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('machines')
+    expect(mockSupabase.update).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'stopped' })
+    )
+  })
+
+  it('closes SQLite database', async () => {
+    await shutdown.execute()
+
+    expect(mockDb.close).toHaveBeenCalled()
+  })
+
+  it('clears heartbeat and task timeout', async () => {
+    const heartbeat = setInterval(() => {}, 60000)
+    const taskTimeout = setTimeout(() => {}, 60000)
+    shutdown.heartbeatInterval = heartbeat
+    shutdown.taskTimeout = taskTimeout
+
+    await shutdown.execute()
+
+    // Verify they were cleared (no assertion needed — if not cleared, test process hangs)
+    clearInterval(heartbeat) // cleanup
+    clearTimeout(taskTimeout)
+  })
+
+  it('only executes once (idempotent)', async () => {
+    await shutdown.execute()
+    await shutdown.execute() // second call should be no-op
+
+    // abort should only be called once
+    const agent = mockAgents.get('pm')
+    expect(agent.abort).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not update task if none is running', async () => {
+    shutdown.currentTask = null
+
+    await shutdown.execute()
+
+    // Should still update machine but not task
+    const fromCalls = mockSupabase.from.mock.calls.map(c => c[0])
+    expect(fromCalls).toContain('machines')
+    // tasks update should not happen
+    const updateCalls = mockSupabase.update.mock.calls
+    const hasTaskUpdate = updateCalls.some(c => c[0]?.status === 'queued')
+    expect(hasTaskUpdate).toBe(false)
+  })
+})

--- a/tests/unit/broker/healthEndpoint.test.js
+++ b/tests/unit/broker/healthEndpoint.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createHealthEndpoint } from '../../../broker/lib/healthEndpoint.js'
+
+describe('healthEndpoint', () => {
+  let handler
+
+  beforeEach(() => {
+    handler = createHealthEndpoint(() => ({
+      healthy: true,
+      agents: [
+        { role: 'pm', status: 'active', pid: 1234 }
+      ],
+      currentTask: {
+        id: 'task-123',
+        status: 'running',
+        startedAt: '2026-03-11T00:00:00Z'
+      }
+    }))
+  })
+
+  it('returns a request handler function', () => {
+    expect(typeof handler).toBe('function')
+  })
+
+  it('responds with 200 and health data for GET /health', () => {
+    const req = { method: 'GET', url: '/health' }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    const data = JSON.parse(res.body)
+    expect(data.status).toBe('healthy')
+    expect(data.mode).toBe('cloud')
+    expect(data.agents).toHaveLength(1)
+    expect(data.agents[0].role).toBe('pm')
+    expect(data.task.id).toBe('task-123')
+    expect(data).toHaveProperty('uptime')
+  })
+
+  it('returns unhealthy status when state is unhealthy', () => {
+    const unhealthyHandler = createHealthEndpoint(() => ({
+      healthy: false,
+      agents: [],
+      currentTask: null
+    }))
+
+    const req = { method: 'GET', url: '/health' }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    unhealthyHandler(req, res)
+
+    expect(res.statusCode).toBe(503)
+    const data = JSON.parse(res.body)
+    expect(data.status).toBe('unhealthy')
+  })
+
+  it('returns null task when no task is active', () => {
+    const idleHandler = createHealthEndpoint(() => ({
+      healthy: true,
+      agents: [{ role: 'pm', status: 'idle', pid: 1234 }],
+      currentTask: null
+    }))
+
+    const req = { method: 'GET', url: '/health' }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    idleHandler(req, res)
+
+    const data = JSON.parse(res.body)
+    expect(data.task).toBeNull()
+  })
+})

--- a/tests/unit/broker/injectEndpoint.test.js
+++ b/tests/unit/broker/injectEndpoint.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createInjectEndpoint } from '../../../broker/lib/injectEndpoint.js'
+
+describe('injectEndpoint', () => {
+  let handler
+  let mockDb
+  let mockDeliverMessage
+
+  beforeEach(() => {
+    mockDb = {
+      prepare: vi.fn(() => ({
+        run: vi.fn(() => ({ lastInsertRowid: 42 }))
+      }))
+    }
+    mockDeliverMessage = vi.fn()
+
+    handler = createInjectEndpoint({
+      db: mockDb,
+      machineJwt: 'valid-jwt-token',
+      sessionId: 'session-123',
+      deliverMessage: mockDeliverMessage
+    })
+  })
+
+  it('returns a request handler function', () => {
+    expect(typeof handler).toBe('function')
+  })
+
+  it('rejects requests without authorization header', () => {
+    const req = {
+      method: 'POST',
+      url: '/api/inject-message',
+      headers: {},
+      body: { to: 'pm', type: 'TASK_ASSIGNMENT', content: 'Do something' }
+    }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects requests with invalid JWT', () => {
+    const req = {
+      method: 'POST',
+      url: '/api/inject-message',
+      headers: { authorization: 'Bearer wrong-token' },
+      body: { to: 'pm', type: 'TASK_ASSIGNMENT', content: 'Do something' }
+    }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(res.statusCode).toBe(401)
+  })
+
+  it('rejects requests with missing required fields', () => {
+    const req = {
+      method: 'POST',
+      url: '/api/inject-message',
+      headers: { authorization: 'Bearer valid-jwt-token' },
+      body: { to: 'pm' } // missing type and content
+    }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(res.statusCode).toBe(400)
+  })
+
+  it('writes valid message to SQLite and returns success', () => {
+    const req = {
+      method: 'POST',
+      url: '/api/inject-message',
+      headers: { authorization: 'Bearer valid-jwt-token' },
+      body: { to: 'pm', type: 'TASK_ASSIGNMENT', content: 'Build a feature' }
+    }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(mockDb.prepare).toHaveBeenCalled()
+    const data = JSON.parse(res.body)
+    expect(data.ok).toBe(true)
+  })
+
+  it('calls deliverMessage after writing to SQLite', () => {
+    const req = {
+      method: 'POST',
+      url: '/api/inject-message',
+      headers: { authorization: 'Bearer valid-jwt-token' },
+      body: { to: 'pm', type: 'TASK_ASSIGNMENT', content: 'Build a feature' }
+    }
+    const res = {
+      statusCode: null,
+      headers: {},
+      body: null,
+      writeHead(code, headers) { this.statusCode = code; this.headers = headers },
+      end(body) { this.body = body }
+    }
+
+    handler(req, res)
+
+    expect(mockDeliverMessage).toHaveBeenCalledWith('pm', expect.any(String))
+  })
+})

--- a/tests/unit/broker/outboxPoster.test.js
+++ b/tests/unit/broker/outboxPoster.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { OutboxPoster } from '../../../broker/lib/outboxPoster.js'
+
+describe('OutboxPoster', () => {
+  let mockSupabase
+  let poster
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn(() => mockSupabase),
+      insert: vi.fn(() => ({ error: null }))
+    }
+
+    poster = new OutboxPoster({
+      supabase: mockSupabase,
+      taskId: 'task-abc',
+      tenantId: 'tenant-xyz'
+    })
+  })
+
+  describe('shouldPost', () => {
+    it('returns true for messages to human', () => {
+      expect(poster.shouldPost({ to_agent: 'human', message_type: 'STATUS_UPDATE' })).toBe(true)
+    })
+
+    it('returns false for agent-to-agent messages', () => {
+      expect(poster.shouldPost({ to_agent: 'engineer', message_type: 'TASK_ASSIGNMENT' })).toBe(false)
+    })
+
+    it('returns false for messages to team', () => {
+      expect(poster.shouldPost({ to_agent: 'team', message_type: 'STATUS_UPDATE' })).toBe(false)
+    })
+  })
+
+  describe('post', () => {
+    it('posts message to Supabase pm_outbox', async () => {
+      await poster.post({
+        message_type: 'HUMAN_QUESTION',
+        content: 'Should we use REST or GraphQL?'
+      })
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('pm_outbox')
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          task_id: 'task-abc',
+          tenant_id: 'tenant-xyz',
+          type: 'HUMAN_QUESTION',
+          content: 'Should we use REST or GraphQL?'
+        })
+      )
+    })
+
+    it('sets requires_response for HUMAN_QUESTION', async () => {
+      await poster.post({
+        message_type: 'HUMAN_QUESTION',
+        content: 'Question?'
+      })
+
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ requires_response: true })
+      )
+    })
+
+    it('sets requires_response for APPROVAL_REQUEST', async () => {
+      await poster.post({
+        message_type: 'APPROVAL_REQUEST',
+        content: 'Please approve'
+      })
+
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ requires_response: true })
+      )
+    })
+
+    it('does not set requires_response for STATUS_UPDATE', async () => {
+      await poster.post({
+        message_type: 'STATUS_UPDATE',
+        content: 'Progress update'
+      })
+
+      expect(mockSupabase.insert).toHaveBeenCalledWith(
+        expect.objectContaining({ requires_response: false })
+      )
+    })
+  })
+})

--- a/tests/unit/broker/taskManager.test.js
+++ b/tests/unit/broker/taskManager.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TaskManager } from '../../../broker/lib/taskManager.js'
+
+describe('TaskManager', () => {
+  let mockSupabase
+  let mockDb
+  let tm
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: vi.fn(() => mockSupabase),
+      select: vi.fn(() => mockSupabase),
+      update: vi.fn(() => mockSupabase),
+      insert: vi.fn(() => mockSupabase),
+      eq: vi.fn(() => mockSupabase),
+      order: vi.fn(() => mockSupabase),
+      limit: vi.fn(() => mockSupabase),
+      single: vi.fn(() => ({
+        data: {
+          id: 'task-abc',
+          title: 'Build auth flow',
+          description: 'Implement OAuth',
+          status: 'queued',
+          projects: { name: 'my-project', repo_url: 'https://github.com/test/repo' },
+          priority: 1,
+          tenant_id: 'tenant-xyz'
+        },
+        error: null
+      }))
+    }
+
+    mockDb = {
+      prepare: vi.fn(() => ({
+        run: vi.fn(() => ({ lastInsertRowid: 1 }))
+      }))
+    }
+
+    tm = new TaskManager({ supabase: mockSupabase, db: mockDb, sessionId: 'session-1' })
+  })
+
+  describe('loadTask', () => {
+    it('fetches task from Supabase by ID', async () => {
+      const task = await tm.loadTask('task-abc')
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+      expect(mockSupabase.select).toHaveBeenCalledWith('*, projects(*)')
+      expect(mockSupabase.eq).toHaveBeenCalledWith('id', 'task-abc')
+      expect(task.id).toBe('task-abc')
+    })
+
+    it('updates task status to running', async () => {
+      await tm.loadTask('task-abc')
+
+      // Should call update with status='running'
+      expect(mockSupabase.update).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'running' })
+      )
+    })
+
+    it('throws when task not found', async () => {
+      mockSupabase.single = vi.fn(() => ({ data: null, error: { message: 'not found' } }))
+
+      await expect(tm.loadTask('nonexistent')).rejects.toThrow()
+    })
+  })
+
+  describe('completeTask', () => {
+    it('updates task to completed in Supabase', async () => {
+      await tm.completeTask('task-abc', {
+        summary: 'Auth flow implemented',
+        prUrl: 'https://github.com/test/repo/pull/1',
+        costUsd: 0.50
+      })
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+      expect(mockSupabase.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'completed',
+          result_summary: 'Auth flow implemented',
+          github_pr_url: 'https://github.com/test/repo/pull/1'
+        })
+      )
+    })
+  })
+
+  describe('failTask', () => {
+    it('updates task to failed in Supabase', async () => {
+      await tm.failTask('task-abc', 'Exceeded max duration')
+
+      expect(mockSupabase.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          error: 'Exceeded max duration'
+        })
+      )
+    })
+  })
+
+  describe('assignTaskToPm', () => {
+    it('writes TASK_ASSIGNMENT message to SQLite', () => {
+      const task = {
+        title: 'Build auth flow',
+        description: 'Implement OAuth',
+        projects: { name: 'my-project', repo_url: 'https://github.com/test/repo' },
+        priority: 1
+      }
+
+      tm.assignTaskToPm(task)
+
+      expect(mockDb.prepare).toHaveBeenCalled()
+      const runCall = mockDb.prepare.mock.results[0].value.run
+      expect(runCall).toHaveBeenCalledWith(
+        'session-1',
+        'system',
+        'pm',
+        'TASK_ASSIGNMENT',
+        expect.stringContaining('Build auth flow')
+      )
+    })
+  })
+
+  describe('checkForQueuedTasks', () => {
+    it('returns next queued task if available', async () => {
+      tm.currentProjectId = 'project-1'
+      mockSupabase.single = vi.fn(() => ({
+        data: { id: 'task-next', title: 'Next task', status: 'queued' },
+        error: null
+      }))
+
+      const next = await tm.checkForQueuedTasks()
+
+      expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+      expect(mockSupabase.eq).toHaveBeenCalledWith('status', 'queued')
+      expect(next).toBeTruthy()
+      expect(next.id).toBe('task-next')
+    })
+
+    it('returns null when no queued tasks', async () => {
+      tm.currentProjectId = 'project-1'
+      mockSupabase.single = vi.fn(() => ({ data: null, error: null }))
+
+      const next = await tm.checkForQueuedTasks()
+
+      expect(next).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements Story #21: Broker cloud mode — adds `CC_MODE=cloud` to the broker that replaces PTY spawning with Pi RPC, removes socket.io/FIFO agent messaging, adds HTTP endpoints, and integrates with Supabase for task lifecycle and PM outbox.

- **Pi RPC spawning**: `cloudAgent.js` spawns Pi agents via `--mode rpc` with JSONL stdin/stdout pipes, using `message` field (not `text`)
- **HTTP endpoints**: `GET /health` (Fly.io health checks) and `POST /api/inject-message` (JWT-validated message injection)
- **Supabase integration**: Task lifecycle manager (load/complete/fail/queue), PM outbox bridge (human-bound messages → Supabase), 60s heartbeat
- **Graceful shutdown**: SIGTERM handler aborts agents, flushes state to Supabase, closes SQLite
- **Local mode unchanged**: All cloud code wrapped in `isCloudMode` guards, local mode regression-free

Closes #21

## Test plan

- [x] 39 new unit tests (cloudAgent, healthEndpoint, injectEndpoint, taskManager, outboxPoster, gracefulShutdown)
- [x] All 231 tests passing (192 baseline + 39 new)
- [x] Local mode smoke tested — starts and shuts down correctly
- [x] `node --check broker/server.js` passes syntax validation
- [ ] Cloud mode end-to-end test (requires Supabase + Pi runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)