### PR TITLE
Add Fly.io Machine lifecycle management (#18)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@lydell/node-pty-darwin-arm64": "^1.2.0-beta.7",
         "@supabase/supabase-js": "^2.99.0",
         "drizzle-orm": "^0.45.1",
+        "jose": "^6.2.1",
         "next": "^16.1.6",
         "node-pty": "^1.1.0",
         "postgres": "^3.4.8",
@@ -373,6 +374,8 @@
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
 
     "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@lydell/node-pty-darwin-arm64": "^1.2.0-beta.7",
     "@supabase/supabase-js": "^2.99.0",
     "drizzle-orm": "^0.45.1",
+    "jose": "^6.2.1",
     "next": "^16.1.6",
     "node-pty": "^1.1.0",
     "postgres": "^3.4.8",

--- a/src/db/schema/machines.ts
+++ b/src/db/schema/machines.ts
@@ -10,6 +10,7 @@ export const machines = pgTable('machines', {
   taskId: uuid('task_id').references(() => tasks.id, { onDelete: 'set null' }),
   flyMachineId: text('fly_machine_id'),
   flyAppName: text('fly_app_name'),
+  machineJwt: text('machine_jwt'),
   status: text('status').default('starting'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow(),

--- a/src/lib/fly/client.ts
+++ b/src/lib/fly/client.ts
@@ -1,0 +1,97 @@
+import {
+  type CreateMachineRequest,
+  type FlyMachine,
+  type CreateVolumeRequest,
+  type FlyVolume,
+  FlyApiError,
+} from './types'
+
+export interface FlyClient {
+  createMachine(config: CreateMachineRequest): Promise<FlyMachine>
+  getMachine(machineId: string): Promise<FlyMachine>
+  startMachine(machineId: string): Promise<void>
+  stopMachine(machineId: string): Promise<void>
+  destroyMachine(machineId: string): Promise<void>
+  listMachines(): Promise<FlyMachine[]>
+  waitForState(machineId: string, state: string, timeout?: number, pollInterval?: number): Promise<void>
+  createVolume(config: CreateVolumeRequest): Promise<FlyVolume>
+  getVolume(volumeId: string): Promise<FlyVolume>
+  deleteVolume(volumeId: string): Promise<void>
+  listVolumes(): Promise<FlyVolume[]>
+}
+
+const MAX_RETRIES = 2
+const RETRY_DELAY_MS = 1000
+
+export function createFlyClient(): FlyClient {
+  const token = process.env.FLY_API_TOKEN!
+  const appName = process.env.FLY_APP_NAME!
+  const baseUrl = `https://api.machines.dev/v1/apps/${appName}`
+
+  async function request<T>(
+    path: string,
+    method: string,
+    body?: unknown,
+    retries = MAX_RETRIES,
+  ): Promise<T> {
+    const url = `${baseUrl}${path}`
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+    }
+    if (body) {
+      headers['Content-Type'] = 'application/json'
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    })
+
+    if (!response.ok) {
+      // Retry on 5xx
+      if (response.status >= 500 && retries > 0) {
+        await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+        return request<T>(path, method, body, retries - 1)
+      }
+
+      const text = await response.text().catch(() => 'Unknown error')
+      throw new FlyApiError(response.status, `Fly API ${method} ${path}: ${response.status} ${text}`)
+    }
+
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T
+    }
+
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('application/json')) {
+      return response.json() as T
+    }
+
+    return undefined as T
+  }
+
+  return {
+    createMachine: (config) => request<FlyMachine>('/machines', 'POST', config),
+    getMachine: (machineId) => request<FlyMachine>(`/machines/${machineId}`, 'GET'),
+    startMachine: (machineId) => request<void>(`/machines/${machineId}/start`, 'POST'),
+    stopMachine: (machineId) => request<void>(`/machines/${machineId}/stop`, 'POST'),
+    destroyMachine: (machineId) => request<void>(`/machines/${machineId}`, 'DELETE'),
+    listMachines: () => request<FlyMachine[]>('/machines', 'GET'),
+
+    async waitForState(machineId, targetState, timeout = 30000, pollInterval = 1000) {
+      const deadline = Date.now() + timeout
+      while (Date.now() < deadline) {
+        const machine = await this.getMachine(machineId)
+        if (machine.state === targetState) return
+        await new Promise(resolve => setTimeout(resolve, pollInterval))
+      }
+      throw new FlyApiError(408, `Timeout waiting for machine ${machineId} to reach state ${targetState}`, machineId)
+    },
+
+    createVolume: (config) => request<FlyVolume>('/volumes', 'POST', config),
+    getVolume: (volumeId) => request<FlyVolume>(`/volumes/${volumeId}`, 'GET'),
+    deleteVolume: (volumeId) => request<void>(`/volumes/${volumeId}`, 'DELETE'),
+    listVolumes: () => request<FlyVolume[]>('/volumes', 'GET'),
+  }
+}

--- a/src/lib/fly/config.ts
+++ b/src/lib/fly/config.ts
@@ -1,0 +1,60 @@
+import type { CreateMachineRequest } from './types'
+
+const DEFAULT_IMAGE = 'registry.fly.io/cdt-machines:latest'
+const DEFAULT_REGION = 'iad'
+
+/**
+ * Build a Fly Machine config for a project.
+ * See Fly Machines API docs for config structure.
+ */
+export function buildMachineConfig(params: {
+  projectId: string
+  tenantId: string
+  volumeId: string
+  env: Record<string, string>
+}): CreateMachineRequest {
+  const shortTenant = params.tenantId.substring(0, 8)
+  const shortProject = params.projectId.substring(0, 8)
+
+  return {
+    name: `cdt-${shortTenant}-${shortProject}`,
+    region: DEFAULT_REGION,
+    config: {
+      image: DEFAULT_IMAGE,
+      env: params.env,
+      guest: {
+        cpu_kind: 'shared',
+        cpus: 1,
+        memory_mb: 1024,
+      },
+      auto_destroy: false,
+      restart: { policy: 'on-failure' },
+      services: [
+        {
+          ports: [{ port: 443, handlers: ['tls', 'http'] }],
+          protocol: 'tcp',
+          internal_port: 3100,
+        },
+      ],
+      checks: {
+        health: {
+          type: 'http',
+          port: 3100,
+          path: '/health',
+          interval: '30s',
+          timeout: '5s',
+        },
+      },
+      mounts: [
+        {
+          volume: params.volumeId,
+          path: '/data',
+        },
+      ],
+      stop_config: {
+        timeout: '10s',
+        signal: 'SIGTERM',
+      },
+    },
+  }
+}

--- a/src/lib/fly/index.ts
+++ b/src/lib/fly/index.ts
@@ -1,0 +1,15 @@
+export { createFlyClient } from './client'
+export type { FlyClient } from './client'
+export { ensureMachineRunning, findMachineForProject, injectMessage } from './machines'
+export { generateMachineJwt, verifyMachineJwt } from './jwt'
+export { ensureVolume } from './volumes'
+export { buildMachineConfig } from './config'
+export type {
+  FlyMachine,
+  FlyVolume,
+  CreateMachineRequest,
+  CreateVolumeRequest,
+  MachineRecord,
+  InjectPayload,
+  FlyApiError,
+} from './types'

--- a/src/lib/fly/jwt.ts
+++ b/src/lib/fly/jwt.ts
@@ -1,0 +1,36 @@
+import { SignJWT, jwtVerify } from 'jose'
+
+const JWT_EXPIRY = '30d'
+
+function getSecret() {
+  const secret = process.env.MACHINE_JWT_SECRET
+  if (!secret) throw new Error('MACHINE_JWT_SECRET env var is required')
+  return new TextEncoder().encode(secret)
+}
+
+/**
+ * Generate a Machine JWT for authenticating Vercel → Machine communication.
+ * Contains projectId and tenantId claims. Expires in 30 days.
+ */
+export async function generateMachineJwt(projectId: string, tenantId: string): Promise<string> {
+  return new SignJWT({ projectId, tenantId })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setIssuedAt()
+    .setExpirationTime(JWT_EXPIRY)
+    .sign(getSecret())
+}
+
+/**
+ * Verify a Machine JWT and return the claims.
+ * Used by the broker inside a Machine to validate incoming requests.
+ */
+export async function verifyMachineJwt(
+  token: string
+): Promise<{ projectId: string; tenantId: string; iat?: number }> {
+  const { payload } = await jwtVerify(token, getSecret())
+  return {
+    projectId: payload.projectId as string,
+    tenantId: payload.tenantId as string,
+    iat: payload.iat,
+  }
+}

--- a/src/lib/fly/machines.ts
+++ b/src/lib/fly/machines.ts
@@ -1,0 +1,231 @@
+import { createFlyClient } from './client'
+import { createAdminClient } from '../../db/supabase'
+import { generateMachineJwt } from './jwt'
+import { ensureVolume } from './volumes'
+import { buildMachineConfig } from './config'
+import { FlyApiError, type MachineRecord, type InjectPayload } from './types'
+
+const INJECT_RETRY_DELAY_MS = 2000
+
+/**
+ * Ensure a Fly Machine is running for a project.
+ * Returns existing running machine, starts stopped machine, or creates new one.
+ */
+export async function ensureMachineRunning(
+  projectId: string,
+  tenantId: string,
+): Promise<MachineRecord> {
+  const supabase = createAdminClient()
+  const flyClient = createFlyClient()
+
+  // Check for existing machine
+  const { data: machines } = await supabase
+    .from('machines')
+    .select('*')
+    .eq('project_id', projectId)
+    .not('status', 'in', '("destroyed","failed")')
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  const existing = machines?.[0] as MachineRecord | undefined
+
+  // Case 1: Running machine — return as-is
+  if (existing && existing.status === 'running') {
+    return existing
+  }
+
+  // Case 2: Stopped machine — start it
+  if (existing && existing.status === 'stopped' && existing.fly_machine_id) {
+    await flyClient.startMachine(existing.fly_machine_id)
+    await flyClient.waitForState(existing.fly_machine_id, 'started', 30000)
+
+    await supabase
+      .from('machines')
+      .update({ status: 'running', updated_at: new Date().toISOString() })
+      .eq('id', existing.id)
+
+    return { ...existing, status: 'running' }
+  }
+
+  // Case 3: No machine — create new one
+  const machineJwt = await generateMachineJwt(projectId, tenantId)
+  const volumeId = await ensureVolume(projectId, tenantId)
+  const env = await resolveMachineEnv(projectId, tenantId, machineJwt)
+  const config = buildMachineConfig({ projectId, tenantId, volumeId, env })
+
+  const flyMachine = await flyClient.createMachine(config)
+  await flyClient.waitForState(flyMachine.id, 'started', 60000)
+
+  const appName = process.env.FLY_APP_NAME!
+
+  const { data: inserted } = await supabase
+    .from('machines')
+    .insert({
+      project_id: projectId,
+      tenant_id: tenantId,
+      fly_machine_id: flyMachine.id,
+      fly_app_name: appName,
+      status: 'running',
+      machine_jwt: machineJwt,
+    })
+    .select()
+
+  return (inserted?.[0] as MachineRecord) ?? {
+    id: 'unknown',
+    project_id: projectId,
+    tenant_id: tenantId,
+    task_id: null,
+    fly_machine_id: flyMachine.id,
+    fly_app_name: appName,
+    status: 'running',
+    machine_jwt: machineJwt,
+    agents: null,
+    cost_summary: null,
+  }
+}
+
+/**
+ * Find a running Machine for a project.
+ * Reconciles DB state with Fly API to handle drift.
+ */
+export async function findMachineForProject(
+  projectId: string,
+): Promise<MachineRecord | null> {
+  const supabase = createAdminClient()
+  const flyClient = createFlyClient()
+
+  const { data: machines } = await supabase
+    .from('machines')
+    .select('*')
+    .eq('project_id', projectId)
+    .not('status', 'in', '("destroyed","failed")')
+    .order('created_at', { ascending: false })
+    .limit(1)
+
+  const machine = machines?.[0] as MachineRecord | undefined
+  if (!machine || !machine.fly_machine_id) return null
+
+  // Reconcile with Fly API
+  try {
+    const flyState = await flyClient.getMachine(machine.fly_machine_id)
+    const dbStatus = flyStateToDbStatus(flyState.state)
+
+    if (dbStatus !== machine.status) {
+      await supabase
+        .from('machines')
+        .update({ status: dbStatus, updated_at: new Date().toISOString() })
+        .eq('id', machine.id)
+      machine.status = dbStatus
+    }
+
+    if (dbStatus === 'destroyed') return null
+    return machine
+  } catch {
+    // Machine not found in Fly — mark as destroyed
+    await supabase
+      .from('machines')
+      .update({ status: 'destroyed', updated_at: new Date().toISOString() })
+      .eq('id', machine.id)
+    return null
+  }
+}
+
+/**
+ * Inject a message into a running Machine's broker.
+ * Authenticates with the Machine's JWT.
+ */
+export async function injectMessage(
+  machine: MachineRecord,
+  payload: InjectPayload,
+): Promise<void> {
+  const url = `https://${machine.fly_app_name}.fly.dev/api/inject-message`
+
+  async function attempt() {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${machine.machine_jwt}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+
+    if (response.status === 401 || response.status === 403) {
+      throw new FlyApiError(response.status, 'Machine JWT mismatch — unauthorized')
+    }
+
+    if (!response.ok) {
+      throw new FlyApiError(response.status, `Inject message failed: ${response.status}`)
+    }
+  }
+
+  try {
+    await attempt()
+  } catch (err) {
+    if (err instanceof FlyApiError && (err.status === 401 || err.status === 403)) {
+      throw err // Don't retry auth errors
+    }
+    // Retry once after delay for transient errors
+    await new Promise(resolve => setTimeout(resolve, INJECT_RETRY_DELAY_MS))
+    await attempt()
+  }
+}
+
+/** Resolve env vars for a new Machine (provider keys, GitHub token, JWT, Supabase) */
+async function resolveMachineEnv(
+  projectId: string,
+  tenantId: string,
+  machineJwt: string,
+): Promise<Record<string, string>> {
+  const supabase = createAdminClient()
+
+  // Fetch provider API keys from Vault
+  const { data: apiKeys } = await supabase
+    .from('tenant_api_keys')
+    .select('provider, vault_secret_id')
+    .eq('tenant_id', tenantId)
+
+  const env: Record<string, string> = {}
+  for (const key of apiKeys ?? []) {
+    if (key.vault_secret_id) {
+      const { data } = await supabase.rpc('get_secret', { secret_id: key.vault_secret_id })
+      if (data) env[`${key.provider.toUpperCase()}_API_KEY`] = data
+    }
+  }
+
+  // Fetch GitHub token
+  const { data: ghConns } = await supabase
+    .from('github_connections')
+    .select('token_vault_id')
+    .eq('tenant_id', tenantId)
+    .limit(1)
+
+  if (ghConns?.[0]?.token_vault_id) {
+    const { data } = await supabase.rpc('get_secret', { secret_id: ghConns[0].token_vault_id })
+    if (data) env.GITHUB_TOKEN = data
+  }
+
+  return {
+    ...env,
+    MACHINE_JWT: machineJwt,
+    PROJECT_ID: projectId,
+    TENANT_ID: tenantId,
+    SUPABASE_URL: process.env.SUPABASE_URL ?? '',
+    SUPABASE_SERVICE_ROLE_KEY: process.env.SUPABASE_SERVICE_ROLE_KEY ?? '',
+    CC_MODE: 'cloud',
+    NODE_ENV: 'production',
+  }
+}
+
+function flyStateToDbStatus(flyState: string): string {
+  const map: Record<string, string> = {
+    created: 'starting',
+    starting: 'starting',
+    started: 'running',
+    stopping: 'stopping',
+    stopped: 'stopped',
+    destroying: 'destroying',
+    destroyed: 'destroyed',
+  }
+  return map[flyState] ?? flyState
+}

--- a/src/lib/fly/types.ts
+++ b/src/lib/fly/types.ts
@@ -1,0 +1,99 @@
+/** Fly Machines REST API types */
+
+export interface CreateMachineRequest {
+  name?: string
+  region?: string
+  config: {
+    image: string
+    env: Record<string, string>
+    guest: { cpu_kind: string; cpus: number; memory_mb: number }
+    auto_destroy: boolean
+    restart: { policy: string }
+    services: Array<{
+      ports: Array<{ port: number; handlers: string[] }>
+      protocol: string
+      internal_port: number
+    }>
+    checks: Record<string, {
+      type: string
+      port: number
+      path: string
+      interval: string
+      timeout: string
+    }>
+    mounts: Array<{
+      volume: string
+      path: string
+    }>
+    stop_config: {
+      timeout: string
+      signal: string
+    }
+  }
+}
+
+export type FlyMachineState =
+  | 'created'
+  | 'starting'
+  | 'started'
+  | 'stopping'
+  | 'stopped'
+  | 'destroying'
+  | 'destroyed'
+
+export interface FlyMachine {
+  id: string
+  name: string
+  state: FlyMachineState
+  region: string
+  config: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+export interface CreateVolumeRequest {
+  name: string
+  size_gb: number
+  region: string
+}
+
+export interface FlyVolume {
+  id: string
+  name: string
+  size_gb: number
+  region: string
+  state: string
+  created_at: string
+}
+
+export interface InjectPayload {
+  type: 'HUMAN_RESPONSE' | 'TASK_ASSIGNMENT' | 'CANCEL'
+  taskId: string
+  content: string
+  from?: string
+}
+
+export interface MachineRecord {
+  id: string
+  project_id: string
+  tenant_id: string
+  task_id: string | null
+  fly_machine_id: string | null
+  fly_app_name: string | null
+  status: string
+  machine_jwt: string | null
+  agents: string[] | null
+  cost_summary: Record<string, unknown> | null
+}
+
+export class FlyApiError extends Error {
+  status: number
+  machineId?: string
+
+  constructor(status: number, message: string, machineId?: string) {
+    super(message)
+    this.name = 'FlyApiError'
+    this.status = status
+    this.machineId = machineId
+  }
+}

--- a/src/lib/fly/volumes.ts
+++ b/src/lib/fly/volumes.ts
@@ -1,0 +1,50 @@
+import { createFlyClient } from './client'
+import { createAdminClient } from '../../db/supabase'
+
+const DEFAULT_VOLUME_SIZE_GB = 10
+const DEFAULT_REGION = 'iad'
+
+/**
+ * Ensure a Fly volume exists for the given project.
+ * Reuses existing volume from project.fly_volume_id if valid,
+ * otherwise creates a new one.
+ */
+export async function ensureVolume(projectId: string, _tenantId: string): Promise<string> {
+  const supabase = createAdminClient()
+  const flyClient = createFlyClient()
+
+  // Check if project already has a volume
+  const { data: projects } = await supabase
+    .from('projects')
+    .select('id, fly_volume_id')
+    .eq('id', projectId)
+
+  const project = projects?.[0]
+  const existingVolumeId = project?.fly_volume_id
+
+  // Try to reuse existing volume
+  if (existingVolumeId) {
+    try {
+      await flyClient.getVolume(existingVolumeId)
+      return existingVolumeId
+    } catch {
+      // Volume no longer exists, create a new one
+    }
+  }
+
+  // Create new volume
+  const shortId = projectId.substring(0, 8)
+  const volume = await flyClient.createVolume({
+    name: `cdt-vol-${shortId}`,
+    size_gb: DEFAULT_VOLUME_SIZE_GB,
+    region: DEFAULT_REGION,
+  })
+
+  // Store volume ID in project
+  await supabase
+    .from('projects')
+    .update({ fly_volume_id: volume.id })
+    .eq('id', projectId)
+
+  return volume.id
+}

--- a/supabase/migrations/006_machine_jwt.sql
+++ b/supabase/migrations/006_machine_jwt.sql
@@ -1,0 +1,6 @@
+-- Add machine_jwt column for Vercel <-> Machine authentication
+ALTER TABLE machines ADD COLUMN machine_jwt TEXT;
+
+-- Add RLS policy for machine_jwt (tenant isolation)
+CREATE POLICY machines_jwt_tenant_isolation ON machines
+  USING (tenant_id = (current_setting('app.tenant_id', true))::uuid);

--- a/tests/lib/fly/client.test.ts
+++ b/tests/lib/fly/client.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { createFlyClient } from '../../../src/lib/fly/client'
+import { FlyApiError } from '../../../src/lib/fly/types'
+
+const MOCK_TOKEN = 'fly-test-token'
+const MOCK_APP = 'cdt-test-app'
+const BASE_URL = `https://api.machines.dev/v1/apps/${MOCK_APP}`
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn()
+  vi.stubGlobal('fetch', fetchMock)
+  vi.stubEnv('FLY_API_TOKEN', MOCK_TOKEN)
+  vi.stubEnv('FLY_APP_NAME', MOCK_APP)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+function jsonResponse(data: any, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('FlyClient', () => {
+  describe('createMachine', () => {
+    it('sends POST to /machines with correct headers and body', async () => {
+      const machine = { id: 'mach-1', name: 'test', state: 'created', region: 'iad' }
+      fetchMock.mockResolvedValueOnce(jsonResponse(machine))
+
+      const client = createFlyClient()
+      const result = await client.createMachine({
+        name: 'test-machine',
+        region: 'iad',
+        config: {
+          image: 'registry.fly.io/cdt:latest',
+          env: { NODE_ENV: 'production' },
+          guest: { cpu_kind: 'shared', cpus: 1, memory_mb: 1024 },
+          auto_destroy: false,
+          restart: { policy: 'on-failure' },
+          services: [],
+          checks: {},
+          mounts: [],
+          stop_config: { timeout: '10s', signal: 'SIGTERM' },
+        },
+      })
+
+      expect(result.id).toBe('mach-1')
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/machines`,
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: `Bearer ${MOCK_TOKEN}`,
+            'Content-Type': 'application/json',
+          }),
+        })
+      )
+    })
+
+    it('throws FlyApiError on non-2xx response', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: 'bad request' }), { status: 400 })
+      )
+
+      const client = createFlyClient()
+      await expect(client.createMachine({} as any)).rejects.toThrow(FlyApiError)
+    })
+  })
+
+  describe('getMachine', () => {
+    it('sends GET to /machines/:id', async () => {
+      const machine = { id: 'mach-1', state: 'started' }
+      fetchMock.mockResolvedValueOnce(jsonResponse(machine))
+
+      const client = createFlyClient()
+      const result = await client.getMachine('mach-1')
+
+      expect(result.id).toBe('mach-1')
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/machines/mach-1`,
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+  })
+
+  describe('startMachine', () => {
+    it('sends POST to /machines/:id/start', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+      const client = createFlyClient()
+      await client.startMachine('mach-1')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/machines/mach-1/start`,
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  describe('stopMachine', () => {
+    it('sends POST to /machines/:id/stop', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+      const client = createFlyClient()
+      await client.stopMachine('mach-1')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/machines/mach-1/stop`,
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+  })
+
+  describe('destroyMachine', () => {
+    it('sends DELETE to /machines/:id', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+      const client = createFlyClient()
+      await client.destroyMachine('mach-1')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/machines/mach-1`,
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+
+  describe('listMachines', () => {
+    it('sends GET to /machines', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 'mach-1' }, { id: 'mach-2' }]))
+
+      const client = createFlyClient()
+      const result = await client.listMachines()
+
+      expect(result).toHaveLength(2)
+    })
+  })
+
+  describe('waitForState', () => {
+    it('resolves when machine reaches target state', async () => {
+      fetchMock
+        .mockResolvedValueOnce(jsonResponse({ id: 'mach-1', state: 'starting' }))
+        .mockResolvedValueOnce(jsonResponse({ id: 'mach-1', state: 'started' }))
+
+      const client = createFlyClient()
+      await client.waitForState('mach-1', 'started', 5000, 50)
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('throws on timeout', async () => {
+      fetchMock.mockImplementation(() => Promise.resolve(jsonResponse({ id: 'mach-1', state: 'starting' })))
+
+      const client = createFlyClient()
+      await expect(
+        client.waitForState('mach-1', 'started', 200, 50)
+      ).rejects.toThrow(/timeout/i)
+    })
+  })
+
+  describe('retry logic', () => {
+    it('retries on 5xx errors', async () => {
+      fetchMock
+        .mockResolvedValueOnce(new Response('Server Error', { status: 500 }))
+        .mockResolvedValueOnce(jsonResponse({ id: 'mach-1', state: 'started' }))
+
+      const client = createFlyClient()
+      const result = await client.getMachine('mach-1')
+
+      expect(result.id).toBe('mach-1')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not retry on 4xx errors', async () => {
+      fetchMock.mockResolvedValue(new Response('Not Found', { status: 404 }))
+
+      const client = createFlyClient()
+      await expect(client.getMachine('nonexistent')).rejects.toThrow(FlyApiError)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('volume operations', () => {
+    it('createVolume sends POST to /volumes', async () => {
+      const volume = { id: 'vol-1', name: 'test-vol', size_gb: 10, region: 'iad', state: 'created' }
+      fetchMock.mockResolvedValueOnce(jsonResponse(volume))
+
+      const client = createFlyClient()
+      const result = await client.createVolume({ name: 'test-vol', size_gb: 10, region: 'iad' })
+
+      expect(result.id).toBe('vol-1')
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/volumes`,
+        expect.objectContaining({ method: 'POST' })
+      )
+    })
+
+    it('listVolumes sends GET to /volumes', async () => {
+      fetchMock.mockResolvedValueOnce(jsonResponse([{ id: 'vol-1' }]))
+
+      const client = createFlyClient()
+      const result = await client.listVolumes()
+
+      expect(result).toHaveLength(1)
+    })
+
+    it('deleteVolume sends DELETE to /volumes/:id', async () => {
+      fetchMock.mockResolvedValueOnce(new Response(null, { status: 200 }))
+
+      const client = createFlyClient()
+      await client.deleteVolume('vol-1')
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `${BASE_URL}/volumes/vol-1`,
+        expect.objectContaining({ method: 'DELETE' })
+      )
+    })
+  })
+})

--- a/tests/lib/fly/config.test.ts
+++ b/tests/lib/fly/config.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import { buildMachineConfig } from '../../../src/lib/fly/config'
+
+describe('buildMachineConfig', () => {
+  it('returns valid CreateMachineRequest structure', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env: { MACHINE_JWT: 'jwt-token', NODE_ENV: 'production' },
+    })
+
+    expect(config.config.image).toContain('registry.fly.io')
+    expect(config.config.guest.cpu_kind).toBe('shared')
+    expect(config.config.guest.cpus).toBe(1)
+    expect(config.config.guest.memory_mb).toBe(1024)
+    expect(config.config.auto_destroy).toBe(false)
+    expect(config.config.restart.policy).toBe('on-failure')
+  })
+
+  it('includes volume mount at /data', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-abc',
+      env: {},
+    })
+
+    expect(config.config.mounts).toHaveLength(1)
+    expect(config.config.mounts[0]).toEqual({ volume: 'vol-abc', path: '/data' })
+  })
+
+  it('includes health check on port 3100', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env: {},
+    })
+
+    expect(config.config.checks.health).toBeDefined()
+    expect(config.config.checks.health.type).toBe('http')
+    expect(config.config.checks.health.port).toBe(3100)
+    expect(config.config.checks.health.path).toBe('/health')
+  })
+
+  it('includes HTTPS service on port 443', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env: {},
+    })
+
+    expect(config.config.services).toHaveLength(1)
+    const service = config.config.services[0]
+    expect(service.internal_port).toBe(3100)
+    expect(service.protocol).toBe('tcp')
+    expect(service.ports).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ port: 443, handlers: ['tls', 'http'] }),
+      ])
+    )
+  })
+
+  it('passes env vars through to config', () => {
+    const env = { MACHINE_JWT: 'secret', PROJECT_ID: 'proj-1', CC_MODE: 'cloud' }
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env,
+    })
+
+    expect(config.config.env).toEqual(env)
+  })
+
+  it('generates machine name from project and tenant IDs', () => {
+    const config = buildMachineConfig({
+      projectId: 'abcdef12-3456-7890-abcd-ef1234567890',
+      tenantId: 'fedcba98-7654-3210-fedc-ba9876543210',
+      volumeId: 'vol-1',
+      env: {},
+    })
+
+    expect(config.name).toBeDefined()
+    expect(config.name).toContain('cdt-')
+  })
+
+  it('sets region to iad', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env: {},
+    })
+
+    expect(config.region).toBe('iad')
+  })
+
+  it('sets stop_config with 10s timeout', () => {
+    const config = buildMachineConfig({
+      projectId: 'proj-1',
+      tenantId: 'tenant-1',
+      volumeId: 'vol-1',
+      env: {},
+    })
+
+    expect(config.config.stop_config.timeout).toBe('10s')
+    expect(config.config.stop_config.signal).toBe('SIGTERM')
+  })
+})

--- a/tests/lib/fly/jwt.test.ts
+++ b/tests/lib/fly/jwt.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { generateMachineJwt, verifyMachineJwt } from '../../../src/lib/fly/jwt'
+
+const TEST_SECRET = 'test-secret-256-bit-key-for-jwt-signing-purposes!!'
+
+beforeEach(() => {
+  vi.stubEnv('MACHINE_JWT_SECRET', TEST_SECRET)
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('Machine JWT', () => {
+  it('generates a valid JWT string', async () => {
+    const token = await generateMachineJwt('proj-1', 'tenant-1')
+    expect(token).toBeTruthy()
+    expect(typeof token).toBe('string')
+    // JWT has 3 parts separated by dots
+    expect(token.split('.')).toHaveLength(3)
+  })
+
+  it('round-trips: generate then verify returns correct claims', async () => {
+    const token = await generateMachineJwt('proj-abc', 'tenant-xyz')
+    const claims = await verifyMachineJwt(token)
+
+    expect(claims.projectId).toBe('proj-abc')
+    expect(claims.tenantId).toBe('tenant-xyz')
+  })
+
+  it('includes iat claim', async () => {
+    const token = await generateMachineJwt('proj-1', 'tenant-1')
+    const claims = await verifyMachineJwt(token)
+
+    // iat should be recent (within last 5 seconds)
+    expect(claims.iat).toBeDefined()
+    expect(claims.iat!).toBeGreaterThan(Math.floor(Date.now() / 1000) - 5)
+  })
+
+  it('rejects tokens signed with wrong secret', async () => {
+    const token = await generateMachineJwt('proj-1', 'tenant-1')
+
+    // Change the secret
+    vi.stubEnv('MACHINE_JWT_SECRET', 'wrong-secret-that-does-not-match-original!!')
+
+    await expect(verifyMachineJwt(token)).rejects.toThrow()
+  })
+
+  it('rejects tampered tokens', async () => {
+    const token = await generateMachineJwt('proj-1', 'tenant-1')
+    // Tamper with the payload
+    const parts = token.split('.')
+    parts[1] = parts[1] + 'tampered'
+    const tampered = parts.join('.')
+
+    await expect(verifyMachineJwt(tampered)).rejects.toThrow()
+  })
+
+  it('rejects expired tokens', async () => {
+    // Generate a token that's already expired by mocking Date
+    const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000
+    vi.setSystemTime(thirtyOneDaysAgo)
+
+    const token = await generateMachineJwt('proj-1', 'tenant-1')
+
+    // Restore time
+    vi.useRealTimers()
+
+    await expect(verifyMachineJwt(token)).rejects.toThrow()
+  })
+})

--- a/tests/lib/fly/machines.test.ts
+++ b/tests/lib/fly/machines.test.ts
@@ -1,0 +1,297 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../../../src/lib/fly/client', () => ({
+  createFlyClient: vi.fn(),
+}))
+
+vi.mock('../../../src/lib/fly/jwt', () => ({
+  generateMachineJwt: vi.fn().mockResolvedValue('mock-jwt-token'),
+}))
+
+vi.mock('../../../src/lib/fly/volumes', () => ({
+  ensureVolume: vi.fn().mockResolvedValue('vol-1'),
+}))
+
+vi.mock('../../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { ensureMachineRunning, findMachineForProject, injectMessage } from '../../../src/lib/fly/machines'
+import { createFlyClient } from '../../../src/lib/fly/client'
+import { createAdminClient } from '../../../src/db/supabase'
+import type { MachineRecord } from '../../../src/lib/fly/types'
+
+function mockFlyClient(overrides: Record<string, any> = {}) {
+  const client = {
+    createMachine: vi.fn().mockResolvedValue({ id: 'fly-mach-1', state: 'created' }),
+    getMachine: vi.fn().mockResolvedValue({ id: 'fly-mach-1', state: 'started' }),
+    startMachine: vi.fn().mockResolvedValue(undefined),
+    stopMachine: vi.fn().mockResolvedValue(undefined),
+    waitForState: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  }
+  vi.mocked(createFlyClient).mockReturnValue(client as any)
+  return client
+}
+
+function createChainableQuery(resolvedData: any) {
+  const handler: ProxyHandler<any> = {
+    get(_target, prop) {
+      if (prop === 'then') return (resolve: any) => resolve({ data: resolvedData, error: null })
+      return (..._args: any[]) => new Proxy({}, handler)
+    },
+  }
+  return new Proxy({}, handler)
+}
+
+function mockDb(machineRows: any[] = [], projectRows: any[] = []) {
+  const insertedRows: any[] = []
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'machines') {
+        return {
+          select: () => createChainableQuery(machineRows),
+          insert: vi.fn().mockImplementation((row: any) => {
+            insertedRows.push(row)
+            return { select: () => createChainableQuery([{ ...row, id: 'db-mach-1' }]) }
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }
+      }
+      if (table === 'projects') {
+        return {
+          select: () => createChainableQuery(projectRows),
+        }
+      }
+      if (table === 'tenant_api_keys') {
+        return { select: () => createChainableQuery([]) }
+      }
+      if (table === 'github_connections') {
+        return { select: () => createChainableQuery([]) }
+      }
+      return { select: () => createChainableQuery([]) }
+    }),
+    rpc: vi.fn().mockResolvedValue({ data: 'decrypted-secret' }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return { mockClient, insertedRows }
+}
+
+describe('ensureMachineRunning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('FLY_APP_NAME', 'cdt-test')
+    vi.stubEnv('FLY_API_TOKEN', 'test-token')
+    vi.stubEnv('MACHINE_JWT_SECRET', 'test-secret')
+    vi.stubEnv('SUPABASE_URL', 'http://localhost:54321')
+    vi.stubEnv('SUPABASE_SERVICE_ROLE_KEY', 'test-key')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns existing running machine', async () => {
+    const existingMachine = {
+      id: 'db-1',
+      project_id: 'proj-1',
+      tenant_id: 'tenant-1',
+      fly_machine_id: 'fly-1',
+      fly_app_name: 'cdt-test',
+      status: 'running',
+      machine_jwt: 'existing-jwt',
+    }
+    mockFlyClient()
+    mockDb([existingMachine])
+
+    const result = await ensureMachineRunning('proj-1', 'tenant-1')
+
+    expect(result.id).toBe('db-1')
+    expect(result.status).toBe('running')
+  })
+
+  it('starts a stopped machine', async () => {
+    const stoppedMachine = {
+      id: 'db-1',
+      project_id: 'proj-1',
+      tenant_id: 'tenant-1',
+      fly_machine_id: 'fly-stopped',
+      fly_app_name: 'cdt-test',
+      status: 'stopped',
+      machine_jwt: 'jwt',
+    }
+    const flyClient = mockFlyClient()
+    mockDb([stoppedMachine])
+
+    const result = await ensureMachineRunning('proj-1', 'tenant-1')
+
+    expect(flyClient.startMachine).toHaveBeenCalledWith('fly-stopped')
+    expect(flyClient.waitForState).toHaveBeenCalledWith('fly-stopped', 'started', 30000)
+    expect(result.status).toBe('running')
+  })
+
+  it('creates a new machine when none exists', async () => {
+    const flyClient = mockFlyClient()
+    mockDb([], [{ id: 'proj-1', fly_volume_id: null }])
+
+    const result = await ensureMachineRunning('proj-1', 'tenant-1')
+
+    expect(flyClient.createMachine).toHaveBeenCalled()
+    expect(flyClient.waitForState).toHaveBeenCalled()
+    expect(result).toBeDefined()
+  })
+})
+
+describe('findMachineForProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubEnv('FLY_APP_NAME', 'cdt-test')
+    vi.stubEnv('FLY_API_TOKEN', 'test-token')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns machine record when found and fly state matches', async () => {
+    const machine = {
+      id: 'db-1',
+      fly_machine_id: 'fly-1',
+      status: 'running',
+    }
+    mockFlyClient({ getMachine: vi.fn().mockResolvedValue({ id: 'fly-1', state: 'started' }) })
+    mockDb([machine])
+
+    const result = await findMachineForProject('proj-1')
+
+    expect(result).toBeDefined()
+    expect(result!.id).toBe('db-1')
+  })
+
+  it('returns null when no machine exists', async () => {
+    mockFlyClient()
+    mockDb([])
+
+    const result = await findMachineForProject('proj-1')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns null and marks destroyed when fly machine not found', async () => {
+    const machine = {
+      id: 'db-1',
+      fly_machine_id: 'fly-gone',
+      status: 'running',
+    }
+    mockFlyClient({
+      getMachine: vi.fn().mockRejectedValue(new Error('not found')),
+    })
+    const { mockClient } = mockDb([machine])
+
+    const result = await findMachineForProject('proj-1')
+
+    expect(result).toBeNull()
+    // Should have called update to mark as destroyed
+    const updateCalls = mockClient.from.mock.calls.filter((c: any) => c[0] === 'machines')
+    expect(updateCalls.length).toBeGreaterThan(1)
+  })
+})
+
+describe('injectMessage', () => {
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs to machine inject-message endpoint with JWT auth', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const machine: MachineRecord = {
+      id: 'db-1',
+      project_id: 'proj-1',
+      tenant_id: 'tenant-1',
+      task_id: 'task-1',
+      fly_machine_id: 'fly-1',
+      fly_app_name: 'cdt-test',
+      status: 'running',
+      machine_jwt: 'jwt-token',
+      agents: null,
+      cost_summary: null,
+    }
+
+    await injectMessage(machine, {
+      type: 'HUMAN_RESPONSE',
+      taskId: 'task-1',
+      content: 'Yes, proceed',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://cdt-test.fly.dev/api/inject-message',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer jwt-token',
+          'Content-Type': 'application/json',
+        }),
+      })
+    )
+  })
+
+  it('retries once on 5xx error', async () => {
+    fetchMock
+      .mockResolvedValueOnce(new Response('error', { status: 500 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }))
+
+    const machine: MachineRecord = {
+      id: 'db-1',
+      project_id: 'proj-1',
+      tenant_id: 'tenant-1',
+      task_id: null,
+      fly_machine_id: 'fly-1',
+      fly_app_name: 'cdt-test',
+      status: 'running',
+      machine_jwt: 'jwt',
+      agents: null,
+      cost_summary: null,
+    }
+
+    await injectMessage(machine, {
+      type: 'TASK_ASSIGNMENT',
+      taskId: 'task-1',
+      content: 'New task',
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws on 401/403 without retry', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+
+    const machine: MachineRecord = {
+      id: 'db-1',
+      project_id: 'proj-1',
+      tenant_id: 'tenant-1',
+      task_id: null,
+      fly_machine_id: 'fly-1',
+      fly_app_name: 'cdt-test',
+      status: 'running',
+      machine_jwt: 'bad-jwt',
+      agents: null,
+      cost_summary: null,
+    }
+
+    await expect(
+      injectMessage(machine, { type: 'CANCEL', taskId: 'task-1', content: 'cancel' })
+    ).rejects.toThrow(/unauthorized|jwt/i)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/lib/fly/volumes.test.ts
+++ b/tests/lib/fly/volumes.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('../../../src/lib/fly/client', () => ({
+  createFlyClient: vi.fn(),
+}))
+
+vi.mock('../../../src/db/supabase', () => ({
+  createAdminClient: vi.fn(),
+}))
+
+import { ensureVolume } from '../../../src/lib/fly/volumes'
+import { createFlyClient } from '../../../src/lib/fly/client'
+import { createAdminClient } from '../../../src/db/supabase'
+
+function mockFlyClient(overrides: Record<string, any> = {}) {
+  const client = {
+    createVolume: vi.fn().mockResolvedValue({ id: 'vol-new', name: 'test', size_gb: 10, region: 'iad', state: 'created' }),
+    getVolume: vi.fn().mockResolvedValue({ id: 'vol-existing', state: 'created' }),
+    ...overrides,
+  }
+  vi.mocked(createFlyClient).mockReturnValue(client as any)
+  return client
+}
+
+function mockDb(project: any = null) {
+  const mockClient = {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'projects') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: project ? [project] : [] }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ error: null }),
+          }),
+        }
+      }
+      return {}
+    }),
+  }
+  vi.mocked(createAdminClient).mockReturnValue(mockClient as any)
+  return mockClient
+}
+
+describe('ensureVolume', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reuses existing volume when project has fly_volume_id', async () => {
+    const flyClient = mockFlyClient()
+    mockDb({ id: 'proj-1', fly_volume_id: 'vol-existing' })
+
+    const volumeId = await ensureVolume('proj-1', 'tenant-1')
+
+    expect(volumeId).toBe('vol-existing')
+    expect(flyClient.getVolume).toHaveBeenCalledWith('vol-existing')
+    expect(flyClient.createVolume).not.toHaveBeenCalled()
+  })
+
+  it('creates new volume when project has no fly_volume_id', async () => {
+    const flyClient = mockFlyClient()
+    mockDb({ id: 'proj-1', fly_volume_id: null })
+
+    const volumeId = await ensureVolume('proj-1', 'tenant-1')
+
+    expect(volumeId).toBe('vol-new')
+    expect(flyClient.createVolume).toHaveBeenCalledWith(
+      expect.objectContaining({
+        size_gb: 10,
+        region: 'iad',
+      })
+    )
+  })
+
+  it('creates new volume when existing volume is not found', async () => {
+    const flyClient = mockFlyClient({
+      getVolume: vi.fn().mockRejectedValue(new Error('not found')),
+    })
+    mockDb({ id: 'proj-1', fly_volume_id: 'vol-deleted' })
+
+    const volumeId = await ensureVolume('proj-1', 'tenant-1')
+
+    expect(volumeId).toBe('vol-new')
+    expect(flyClient.createVolume).toHaveBeenCalled()
+  })
+
+  it('updates project with new volume ID after creation', async () => {
+    mockFlyClient()
+    const db = mockDb({ id: 'proj-1', fly_volume_id: null })
+
+    await ensureVolume('proj-1', 'tenant-1')
+
+    // Verify update was called on projects table
+    const updateCalls = db.from.mock.calls.filter((c: any) => c[0] === 'projects')
+    expect(updateCalls.length).toBeGreaterThanOrEqual(2) // select + update
+  })
+})


### PR DESCRIPTION
## Summary

- Fly Machines REST API client (`src/lib/fly/client.ts`) — create/start/stop/destroy machines, volume CRUD, waitForState with retry logic
- Machine lifecycle manager (`src/lib/fly/machines.ts`) — `ensureMachineRunning` (3 state transitions: running/stopped/new), `findMachineForProject` (with Fly API reconciliation for drift detection), `injectMessage` (JWT-authenticated with retry)
- Machine JWT utilities (`src/lib/fly/jwt.ts`) — HS256 signing/verification via jose, 30-day expiry
- Volume management (`src/lib/fly/volumes.ts`) — create or reuse volumes, auto-recovery for deleted volumes
- Machine config builder (`src/lib/fly/config.ts`) — shared CPU, 1GB RAM, port 3100, health checks, volume mounts
- Schema: added `machine_jwt` column to machines table + migration

## Test plan

- [x] 41 tests across 5 test files, all passing
- [x] API client: 14 tests (all HTTP methods, retry on 5xx, no retry on 4xx, waitForState timeout)
- [x] Machine lifecycle: 9 tests (running/stopped/new transitions, Fly API reconciliation, injectMessage auth/retry)
- [x] JWT: 6 tests (round-trip, expiry, tamper rejection, wrong secret)
- [x] Volumes: 4 tests (reuse, create, recovery, project update)
- [x] Config: 8 tests (structure, mounts, services, checks, env passthrough)
- [x] 250 total tests passing, 0 regressions from baseline (209)
- [x] TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)