### PR TITLE
Add container log persistence library (#23)

### DIFF
--- a/src/lib/logging/cost-accumulator.ts
+++ b/src/lib/logging/cost-accumulator.ts
@@ -1,0 +1,47 @@
+import type { CostSummary, TokenCost } from './types'
+
+export class CostAccumulator {
+  private byAgent = new Map<string, TokenCost>()
+  private byProvider = new Map<string, TokenCost>()
+
+  addUsage(agent: string, provider: string, input: number, output: number, costUsd: number): void {
+    this.accumulate(this.byAgent, agent, input, output, costUsd)
+    this.accumulate(this.byProvider, provider, input, output, costUsd)
+  }
+
+  getSummary(): CostSummary {
+    let totalInputTokens = 0
+    let totalOutputTokens = 0
+    let totalCostUsd = 0
+
+    for (const cost of this.byAgent.values()) {
+      totalInputTokens += cost.inputTokens
+      totalOutputTokens += cost.outputTokens
+      totalCostUsd += cost.costUsd
+    }
+
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      totalCostUsd,
+      byAgent: Object.fromEntries(this.byAgent),
+      byProvider: Object.fromEntries(this.byProvider),
+    }
+  }
+
+  reset(): void {
+    this.byAgent.clear()
+    this.byProvider.clear()
+  }
+
+  private accumulate(map: Map<string, TokenCost>, key: string, input: number, output: number, costUsd: number): void {
+    const existing = map.get(key)
+    if (existing) {
+      existing.inputTokens += input
+      existing.outputTokens += output
+      existing.costUsd += costUsd
+    } else {
+      map.set(key, { inputTokens: input, outputTokens: output, costUsd })
+    }
+  }
+}

--- a/src/lib/logging/index.ts
+++ b/src/lib/logging/index.ts
@@ -1,0 +1,4 @@
+export { TaskLogger } from './task-logger'
+export { CostAccumulator } from './cost-accumulator'
+export { setupShutdownHandler } from './shutdown'
+export type { LogEntry, CostSummary, TokenCost } from './types'

--- a/src/lib/logging/shutdown.ts
+++ b/src/lib/logging/shutdown.ts
@@ -1,0 +1,113 @@
+import { stat, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { TaskLogger } from './task-logger'
+
+interface ShutdownParams {
+  taskLogger: TaskLogger
+  taskId: string
+  supabaseAdmin: {
+    from: (table: string) => {
+      update: (data: Record<string, unknown>) => { eq: (col: string, val: string) => Promise<{ error: unknown }> }
+    }
+    storage: {
+      from: (bucket: string) => {
+        upload: (path: string, data: Buffer, opts: Record<string, unknown>) => Promise<{ error: unknown }>
+      }
+    }
+  }
+  onShutdown?: () => Promise<void>
+  /** Max time to wait for onShutdown hook (default: 5000ms) */
+  shutdownTimeoutMs?: number
+  /** Max log file size for upload (default: 5MB) */
+  maxLogSizeBytes?: number
+  /** Base directory for log files (default: /data) */
+  dataDir?: string
+}
+
+interface ShutdownResult {
+  triggerShutdown: () => Promise<void>
+  restore: () => void
+}
+
+function timeout(ms: number): Promise<never> {
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(`Shutdown timeout after ${ms}ms`)), ms),
+  )
+}
+
+export function setupShutdownHandler(params: ShutdownParams): ShutdownResult {
+  const {
+    taskLogger,
+    taskId,
+    supabaseAdmin,
+    onShutdown,
+    shutdownTimeoutMs = 5000,
+    maxLogSizeBytes = 5 * 1024 * 1024,
+    dataDir = '/data',
+  } = params
+
+  async function triggerShutdown(): Promise<void> {
+    console.log('[shutdown] SIGTERM received, flushing logs...')
+    const startTime = Date.now()
+
+    try {
+      // 1. Call onShutdown hook with timeout
+      if (onShutdown) {
+        try {
+          await Promise.race([onShutdown(), timeout(shutdownTimeoutMs)])
+        } catch (err) {
+          console.error('[shutdown] onShutdown hook error or timeout:', err)
+        }
+      }
+
+      // 2. Flush and close task logger
+      await taskLogger.flush()
+      const costSummary = taskLogger.getCostSummary()
+      await taskLogger.close()
+
+      // 3. Update task in Supabase with final cost
+      await supabaseAdmin
+        .from('tasks')
+        .update({
+          cost_tokens: {
+            input: costSummary.totalInputTokens,
+            output: costSummary.totalOutputTokens,
+            by_agent: costSummary.byAgent,
+            by_provider: costSummary.byProvider,
+          },
+          cost_usd: costSummary.totalCostUsd,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', taskId)
+
+      // 4. Upload log file to Supabase Storage if under size limit
+      const logPath = join(dataDir, 'logs', `${taskId}.jsonl`)
+      const fileStat = await stat(logPath).catch(() => null)
+
+      if (fileStat && fileStat.size < maxLogSizeBytes) {
+        const logContent = await readFile(logPath)
+        await supabaseAdmin.storage
+          .from('task-logs')
+          .upload(`${taskId}.jsonl`, logContent, {
+            contentType: 'application/x-ndjson',
+            upsert: true,
+          })
+      }
+
+      console.log(`[shutdown] Flush complete in ${Date.now() - startTime}ms`)
+    } catch (err) {
+      console.error('[shutdown] Error during flush:', err)
+    }
+  }
+
+  const handler = () => {
+    triggerShutdown().finally(() => process.exit(0))
+  }
+
+  process.on('SIGTERM', handler)
+
+  return {
+    triggerShutdown,
+    restore: () => process.removeListener('SIGTERM', handler),
+  }
+}

--- a/src/lib/logging/task-logger.ts
+++ b/src/lib/logging/task-logger.ts
@@ -1,0 +1,83 @@
+import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs'
+import { join } from 'node:path'
+import { CostAccumulator } from './cost-accumulator'
+import type { LogEntry, CostSummary } from './types'
+
+export class TaskLogger {
+  private readonly logPath: string
+  private stream: WriteStream | null
+  private readonly costAccumulator = new CostAccumulator()
+
+  constructor(
+    private readonly taskId: string,
+    dataDir: string,
+  ) {
+    const logDir = join(dataDir, 'logs')
+    mkdirSync(logDir, { recursive: true })
+    this.logPath = join(logDir, `${taskId}.jsonl`)
+    this.stream = createWriteStream(this.logPath, { flags: 'a' })
+  }
+
+  log(entry: LogEntry): void {
+    if (!this.stream) return
+    const line = JSON.stringify(entry) + '\n'
+    this.stream.write(line)
+    process.stdout.write(line)
+  }
+
+  agentEvent(agent: string, event: string, data?: Record<string, unknown>): void {
+    this.log({ ts: new Date().toISOString(), level: 'info', agent, event, ...data })
+  }
+
+  toolCall(agent: string, tool: string, data?: Record<string, unknown>): void {
+    this.log({ ts: new Date().toISOString(), level: 'info', agent, event: 'tool_call', tool, ...data })
+  }
+
+  messageEvent(agent: string, from: string, type: string): void {
+    this.log({ ts: new Date().toISOString(), level: 'info', agent, event: 'message_received', from, type })
+  }
+
+  costEvent(agent: string, input: number, output: number, costUsd: number, provider: string): void {
+    this.costAccumulator.addUsage(agent, provider, input, output, costUsd)
+    this.log({
+      ts: new Date().toISOString(),
+      level: 'info',
+      agent,
+      event: 'cost_update',
+      input_tokens: input,
+      output_tokens: output,
+      cost_usd: costUsd,
+      provider,
+    })
+  }
+
+  error(agent: string, error: Error | string, context?: Record<string, unknown>): void {
+    const message = error instanceof Error ? error.message : error
+    this.log({ ts: new Date().toISOString(), level: 'error', agent, event: 'error', message, ...context })
+  }
+
+  async flush(): Promise<void> {
+    if (!this.stream) return
+    return new Promise<void>((resolve, reject) => {
+      this.stream!.write('', (err) => {
+        if (err) reject(err)
+        else resolve()
+      })
+    })
+  }
+
+  async close(): Promise<void> {
+    if (!this.stream) return
+    await this.flush()
+    return new Promise<void>((resolve) => {
+      this.stream!.end(() => {
+        this.stream = null
+        resolve()
+      })
+    })
+  }
+
+  getCostSummary(): CostSummary {
+    return this.costAccumulator.getSummary()
+  }
+}

--- a/src/lib/logging/types.ts
+++ b/src/lib/logging/types.ts
@@ -1,0 +1,21 @@
+export interface LogEntry {
+  ts: string
+  level: 'info' | 'warn' | 'error'
+  agent?: string
+  event: string
+  [key: string]: unknown
+}
+
+export interface TokenCost {
+  inputTokens: number
+  outputTokens: number
+  costUsd: number
+}
+
+export interface CostSummary {
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalCostUsd: number
+  byAgent: Record<string, TokenCost>
+  byProvider: Record<string, TokenCost>
+}

--- a/tests/lib/logging/cost-accumulator.test.ts
+++ b/tests/lib/logging/cost-accumulator.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { CostAccumulator } from '../../../src/lib/logging/cost-accumulator'
+
+describe('CostAccumulator', () => {
+  let accumulator: CostAccumulator
+
+  beforeEach(() => {
+    accumulator = new CostAccumulator()
+  })
+
+  describe('addUsage', () => {
+    it('tracks a single usage entry', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(1000)
+      expect(summary.totalOutputTokens).toBe(500)
+      expect(summary.totalCostUsd).toBe(0.015)
+    })
+
+    it('accumulates multiple entries for the same agent', () => {
+      accumulator.addUsage('engineer', 'anthropic', 1000, 500, 0.015)
+      accumulator.addUsage('engineer', 'anthropic', 2000, 800, 0.025)
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(3000)
+      expect(summary.totalOutputTokens).toBe(1300)
+      expect(summary.totalCostUsd).toBeCloseTo(0.04)
+      expect(summary.byAgent['engineer'].inputTokens).toBe(3000)
+      expect(summary.byAgent['engineer'].outputTokens).toBe(1300)
+      expect(summary.byAgent['engineer'].costUsd).toBeCloseTo(0.04)
+    })
+
+    it('tracks multiple agents separately', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      accumulator.addUsage('engineer', 'anthropic', 2000, 800, 0.025)
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(3000)
+      expect(summary.totalOutputTokens).toBe(1300)
+      expect(Object.keys(summary.byAgent)).toHaveLength(2)
+      expect(summary.byAgent['pm'].inputTokens).toBe(1000)
+      expect(summary.byAgent['engineer'].inputTokens).toBe(2000)
+    })
+
+    it('tracks multiple providers separately', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      accumulator.addUsage('engineer', 'openai', 2000, 800, 0.010)
+      const summary = accumulator.getSummary()
+
+      expect(Object.keys(summary.byProvider)).toHaveLength(2)
+      expect(summary.byProvider['anthropic'].inputTokens).toBe(1000)
+      expect(summary.byProvider['openai'].inputTokens).toBe(2000)
+    })
+
+    it('accumulates same provider across different agents', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      accumulator.addUsage('engineer', 'anthropic', 2000, 800, 0.025)
+      const summary = accumulator.getSummary()
+
+      expect(summary.byProvider['anthropic'].inputTokens).toBe(3000)
+      expect(summary.byProvider['anthropic'].outputTokens).toBe(1300)
+      expect(summary.byProvider['anthropic'].costUsd).toBeCloseTo(0.04)
+    })
+  })
+
+  describe('getSummary', () => {
+    it('returns zeroes when no usage recorded', () => {
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(0)
+      expect(summary.totalOutputTokens).toBe(0)
+      expect(summary.totalCostUsd).toBe(0)
+      expect(summary.byAgent).toEqual({})
+      expect(summary.byProvider).toEqual({})
+    })
+  })
+
+  describe('reset', () => {
+    it('clears all accumulated state', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      accumulator.addUsage('engineer', 'openai', 2000, 800, 0.025)
+      accumulator.reset()
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(0)
+      expect(summary.totalOutputTokens).toBe(0)
+      expect(summary.totalCostUsd).toBe(0)
+      expect(summary.byAgent).toEqual({})
+      expect(summary.byProvider).toEqual({})
+    })
+
+    it('allows new accumulation after reset', () => {
+      accumulator.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      accumulator.reset()
+      accumulator.addUsage('engineer', 'openai', 500, 200, 0.005)
+      const summary = accumulator.getSummary()
+
+      expect(summary.totalInputTokens).toBe(500)
+      expect(summary.totalOutputTokens).toBe(200)
+      expect(summary.totalCostUsd).toBe(0.005)
+      expect(Object.keys(summary.byAgent)).toEqual(['engineer'])
+    })
+  })
+})

--- a/tests/lib/logging/shutdown.test.ts
+++ b/tests/lib/logging/shutdown.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { setupShutdownHandler } from '../../../src/lib/logging/shutdown'
+import { TaskLogger } from '../../../src/lib/logging/task-logger'
+import { mkdtemp, rm, stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+function createMockSupabase(options?: { updateError?: Error; uploadError?: Error }) {
+  const updateFn = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue(
+      options?.updateError ? { error: options.updateError } : { error: null },
+    ),
+  })
+
+  const uploadFn = vi.fn().mockResolvedValue(
+    options?.uploadError ? { error: options.uploadError } : { error: null },
+  )
+
+  return {
+    from: vi.fn().mockReturnValue({ update: updateFn }),
+    storage: {
+      from: vi.fn().mockReturnValue({ upload: uploadFn }),
+    },
+    _updateFn: updateFn,
+    _uploadFn: uploadFn,
+  }
+}
+
+describe('setupShutdownHandler', () => {
+  let tmpDir: string
+  let logger: TaskLogger
+  let cleanup: (() => void) | undefined
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'shutdown-test-'))
+    logger = new TaskLogger('task-abc', tmpDir)
+  })
+
+  afterEach(async () => {
+    if (cleanup) cleanup()
+    await logger.close().catch(() => {})
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  it('calls flush, updates Supabase with cost summary, and uploads log file', async () => {
+    logger.costEvent('pm', 1000, 500, 0.015, 'anthropic')
+    const mockSupabase = createMockSupabase()
+
+    const { triggerShutdown, restore } = setupShutdownHandler({
+      taskLogger: logger,
+      taskId: 'task-abc',
+      supabaseAdmin: mockSupabase as any,
+      dataDir: tmpDir,
+    })
+    cleanup = restore
+
+    await triggerShutdown()
+
+    // Supabase task update was called
+    expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+    const updateCall = mockSupabase._updateFn.mock.calls[0][0]
+    expect(updateCall.cost_tokens.input).toBe(1000)
+    expect(updateCall.cost_tokens.output).toBe(500)
+    expect(updateCall.cost_usd).toBe(0.015)
+
+    // Log file was uploaded
+    expect(mockSupabase.storage.from).toHaveBeenCalledWith('task-logs')
+    expect(mockSupabase._uploadFn).toHaveBeenCalled()
+    const uploadArgs = mockSupabase._uploadFn.mock.calls[0]
+    expect(uploadArgs[0]).toBe('task-abc.jsonl')
+  })
+
+  it('calls onShutdown hook when provided', async () => {
+    const onShutdown = vi.fn().mockResolvedValue(undefined)
+    const mockSupabase = createMockSupabase()
+
+    const { triggerShutdown, restore } = setupShutdownHandler({
+      taskLogger: logger,
+      taskId: 'task-abc',
+      supabaseAdmin: mockSupabase as any,
+      dataDir: tmpDir,
+      onShutdown,
+    })
+    cleanup = restore
+
+    await triggerShutdown()
+    expect(onShutdown).toHaveBeenCalled()
+  })
+
+  it('times out onShutdown if it hangs', async () => {
+    const hangingShutdown = vi.fn().mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    )
+    const mockSupabase = createMockSupabase()
+
+    const { triggerShutdown, restore } = setupShutdownHandler({
+      taskLogger: logger,
+      taskId: 'task-abc',
+      supabaseAdmin: mockSupabase as any,
+      dataDir: tmpDir,
+      onShutdown: hangingShutdown,
+      shutdownTimeoutMs: 100, // short timeout for test
+    })
+    cleanup = restore
+
+    await triggerShutdown()
+
+    // Should still complete despite hanging onShutdown
+    expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+  })
+
+  it('does not upload log file if over size limit', async () => {
+    // Write enough data to exceed a small limit
+    for (let i = 0; i < 100; i++) {
+      logger.agentEvent('pm', 'event', { data: 'x'.repeat(100) })
+    }
+    await logger.flush()
+
+    const mockSupabase = createMockSupabase()
+
+    const { triggerShutdown, restore } = setupShutdownHandler({
+      taskLogger: logger,
+      taskId: 'task-abc',
+      supabaseAdmin: mockSupabase as any,
+      dataDir: tmpDir,
+      maxLogSizeBytes: 100, // very small limit
+    })
+    cleanup = restore
+
+    await triggerShutdown()
+
+    // Task update should still happen
+    expect(mockSupabase.from).toHaveBeenCalledWith('tasks')
+    // But upload should NOT happen
+    expect(mockSupabase._uploadFn).not.toHaveBeenCalled()
+  })
+
+  it('handles errors during flush without crashing', async () => {
+    const mockSupabase = createMockSupabase({ updateError: new Error('DB down') })
+
+    const { triggerShutdown, restore } = setupShutdownHandler({
+      taskLogger: logger,
+      taskId: 'task-abc',
+      supabaseAdmin: mockSupabase as any,
+      dataDir: tmpDir,
+    })
+    cleanup = restore
+
+    // Should not throw
+    await expect(triggerShutdown()).resolves.not.toThrow()
+  })
+})

--- a/tests/lib/logging/task-logger.test.ts
+++ b/tests/lib/logging/task-logger.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { TaskLogger } from '../../../src/lib/logging/task-logger'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+describe('TaskLogger', () => {
+  let tmpDir: string
+  let logger: TaskLogger
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'task-logger-test-'))
+    logger = new TaskLogger('test-task-123', tmpDir)
+  })
+
+  afterEach(async () => {
+    await logger.close()
+    await rm(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('log', () => {
+    it('writes valid JSONL entries to log file', async () => {
+      logger.log({ ts: '2026-03-11T12:00:00Z', level: 'info', event: 'test_event' })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(1)
+
+      const entry = JSON.parse(lines[0])
+      expect(entry.ts).toBe('2026-03-11T12:00:00Z')
+      expect(entry.level).toBe('info')
+      expect(entry.event).toBe('test_event')
+    })
+
+    it('writes each entry as independently parseable JSON', async () => {
+      logger.log({ ts: '2026-03-11T12:00:00Z', level: 'info', event: 'event_1' })
+      logger.log({ ts: '2026-03-11T12:00:01Z', level: 'warn', event: 'event_2' })
+      logger.log({ ts: '2026-03-11T12:00:02Z', level: 'error', event: 'event_3' })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(3)
+
+      for (const line of lines) {
+        expect(() => JSON.parse(line)).not.toThrow()
+      }
+    })
+
+    it('includes additional fields in log entry', async () => {
+      logger.log({ ts: '2026-03-11T12:00:00Z', level: 'info', event: 'custom', foo: 'bar', count: 42 })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.foo).toBe('bar')
+      expect(entry.count).toBe(42)
+    })
+  })
+
+  describe('agentEvent', () => {
+    it('writes an agent event with auto-generated timestamp', async () => {
+      logger.agentEvent('pm', 'spawned', { model: 'claude-sonnet-4-6' })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.level).toBe('info')
+      expect(entry.agent).toBe('pm')
+      expect(entry.event).toBe('spawned')
+      expect(entry.model).toBe('claude-sonnet-4-6')
+      expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/)
+    })
+  })
+
+  describe('toolCall', () => {
+    it('writes a tool_call event', async () => {
+      logger.toolCall('engineer', 'edit', { file: 'src/index.ts', duration_ms: 150 })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.event).toBe('tool_call')
+      expect(entry.agent).toBe('engineer')
+      expect(entry.tool).toBe('edit')
+      expect(entry.file).toBe('src/index.ts')
+      expect(entry.duration_ms).toBe(150)
+    })
+  })
+
+  describe('messageEvent', () => {
+    it('writes a message_received event', async () => {
+      logger.messageEvent('engineer', 'pm', 'TASK_ASSIGNMENT')
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.event).toBe('message_received')
+      expect(entry.agent).toBe('engineer')
+      expect(entry.from).toBe('pm')
+      expect(entry.type).toBe('TASK_ASSIGNMENT')
+    })
+  })
+
+  describe('costEvent', () => {
+    it('writes a cost_update event and accumulates cost', async () => {
+      logger.costEvent('pm', 1500, 800, 0.015, 'anthropic')
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.event).toBe('cost_update')
+      expect(entry.agent).toBe('pm')
+      expect(entry.input_tokens).toBe(1500)
+      expect(entry.output_tokens).toBe(800)
+      expect(entry.cost_usd).toBe(0.015)
+      expect(entry.provider).toBe('anthropic')
+    })
+
+    it('accumulates costs across multiple events', async () => {
+      logger.costEvent('pm', 1000, 500, 0.015, 'anthropic')
+      logger.costEvent('engineer', 2000, 800, 0.025, 'anthropic')
+
+      const summary = logger.getCostSummary()
+      expect(summary.totalInputTokens).toBe(3000)
+      expect(summary.totalOutputTokens).toBe(1300)
+      expect(summary.totalCostUsd).toBeCloseTo(0.04)
+    })
+  })
+
+  describe('error', () => {
+    it('writes an error event from Error object', async () => {
+      logger.error('pm', new Error('Something broke'), { context: 'spawning' })
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.level).toBe('error')
+      expect(entry.event).toBe('error')
+      expect(entry.agent).toBe('pm')
+      expect(entry.message).toBe('Something broke')
+      expect(entry.context).toBe('spawning')
+    })
+
+    it('writes an error event from string', async () => {
+      logger.error('engineer', 'Connection timeout')
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const entry = JSON.parse(content.trim())
+      expect(entry.level).toBe('error')
+      expect(entry.message).toBe('Connection timeout')
+    })
+  })
+
+  describe('flush', () => {
+    it('ensures all entries are written to disk', async () => {
+      for (let i = 0; i < 100; i++) {
+        logger.log({ ts: new Date().toISOString(), level: 'info', event: `event_${i}` })
+      }
+      await logger.flush()
+
+      const content = await readFile(join(tmpDir, 'logs', 'test-task-123.jsonl'), 'utf-8')
+      const lines = content.trim().split('\n')
+      expect(lines).toHaveLength(100)
+    })
+  })
+
+  describe('close', () => {
+    it('is idempotent', async () => {
+      logger.log({ ts: new Date().toISOString(), level: 'info', event: 'test' })
+      await logger.close()
+      await logger.close() // should not throw
+    })
+  })
+
+  describe('getCostSummary', () => {
+    it('returns empty summary when no costs recorded', () => {
+      const summary = logger.getCostSummary()
+      expect(summary.totalInputTokens).toBe(0)
+      expect(summary.totalOutputTokens).toBe(0)
+      expect(summary.totalCostUsd).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- **CostAccumulator**: Pure in-memory tracker for per-agent and per-provider token usage and costs
- **TaskLogger**: Per-task JSONL logger with dual-write to persistent volume files and stdout (for Fly Logs capture)
- **setupShutdownHandler**: SIGTERM handler that flushes logs, updates Supabase task record with final cost summary, and uploads log files to Supabase Storage (with configurable size limits and timeouts)

## Files Added

| File | Purpose |
|------|---------|
| `src/lib/logging/types.ts` | LogEntry, TokenCost, CostSummary interfaces |
| `src/lib/logging/cost-accumulator.ts` | Token/cost tracking class |
| `src/lib/logging/task-logger.ts` | Per-task JSONL logger |
| `src/lib/logging/shutdown.ts` | Graceful shutdown handler |
| `src/lib/logging/index.ts` | Barrel export |
| `tests/lib/logging/cost-accumulator.test.ts` | 8 tests |
| `tests/lib/logging/task-logger.test.ts` | 13 tests |
| `tests/lib/logging/shutdown.test.ts` | 5 tests |

## Test plan

- [x] CostAccumulator: single/multi agent, single/multi provider, reset, empty state
- [x] TaskLogger: JSONL format, independent line parsing, auto-timestamps, cost delegation, flush, close idempotency
- [x] Shutdown: onShutdown hook, timeout on hanging hooks, Supabase update with cost summary, size-limited upload, error resilience
- [x] 26 new tests, 0 regressions (209 existing tests still pass)

## Note

The `task-logs` Supabase Storage bucket needs manual creation before use. SQL provided in the plan file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)