### PR TITLE
Fix cloud integration gaps 4 and 7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /app /app
 WORKDIR /app
 
+# Install Pi agent runtime (used by broker to spawn agents in RPC mode)
+RUN npm install -g @mariozechner/pi-coding-agent
+
 # Create data directory for volume mount
 RUN mkdir -p /data && chown node:node /data
 

--- a/broker/lib/gracefulShutdown.js
+++ b/broker/lib/gracefulShutdown.js
@@ -1,9 +1,13 @@
+import { stat, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
 /**
  * Handles graceful SIGTERM shutdown in cloud mode.
  * Aborts agents, flushes state to Supabase, closes SQLite.
+ * Persists cost data and uploads task logs to Supabase Storage.
  */
 export class GracefulShutdown {
-  constructor({ supabase, db, agents, machineId, currentTask, heartbeatInterval, taskTimeout }) {
+  constructor({ supabase, db, agents, machineId, currentTask, heartbeatInterval, taskTimeout, dataDir = '/data' }) {
     this.supabase = supabase
     this.db = db
     this.agents = agents
@@ -11,7 +15,46 @@ export class GracefulShutdown {
     this.currentTask = currentTask
     this.heartbeatInterval = heartbeatInterval
     this.taskTimeout = taskTimeout
+    this.dataDir = dataDir
     this._executed = false
+
+    // Cost tracking (per-agent and per-provider)
+    this._byAgent = new Map()
+    this._byProvider = new Map()
+  }
+
+  addUsage(agent, provider, input, output, costUsd) {
+    this._accumulate(this._byAgent, agent, input, output, costUsd)
+    this._accumulate(this._byProvider, provider, input, output, costUsd)
+  }
+
+  getCostSummary() {
+    let totalInputTokens = 0
+    let totalOutputTokens = 0
+    let totalCostUsd = 0
+    for (const cost of this._byAgent.values()) {
+      totalInputTokens += cost.inputTokens
+      totalOutputTokens += cost.outputTokens
+      totalCostUsd += cost.costUsd
+    }
+    return {
+      totalInputTokens,
+      totalOutputTokens,
+      totalCostUsd,
+      byAgent: Object.fromEntries(this._byAgent),
+      byProvider: Object.fromEntries(this._byProvider),
+    }
+  }
+
+  _accumulate(map, key, input, output, costUsd) {
+    const existing = map.get(key)
+    if (existing) {
+      existing.inputTokens += input
+      existing.outputTokens += output
+      existing.costUsd += costUsd
+    } else {
+      map.set(key, { inputTokens: input, outputTokens: output, costUsd })
+    }
   }
 
   async execute() {
@@ -42,13 +85,30 @@ export class GracefulShutdown {
 
       // 4. Update task status if in-progress
       if (this.currentTask?.status === 'running') {
+        const taskUpdate = {
+          status: 'queued',
+          error: 'Machine stopped during execution'
+        }
+
+        // Include cost data if any usage was recorded
+        const costSummary = this.getCostSummary()
+        if (costSummary.totalInputTokens > 0) {
+          taskUpdate.cost_tokens = {
+            input: costSummary.totalInputTokens,
+            output: costSummary.totalOutputTokens,
+            by_agent: costSummary.byAgent,
+            by_provider: costSummary.byProvider,
+          }
+          taskUpdate.cost_usd = costSummary.totalCostUsd
+        }
+
         await this.supabase
           .from('tasks')
-          .update({
-            status: 'queued',
-            error: 'Machine stopped during execution'
-          })
+          .update(taskUpdate)
           .eq('id', this.currentTask.id)
+
+        // Upload log file to Supabase Storage if it exists and is under 5MB
+        await this._uploadLogFile()
       }
 
       // 5. Update machine status
@@ -66,6 +126,26 @@ export class GracefulShutdown {
       console.log(`[Cloud] Shutdown complete in ${Date.now() - shutdownStart}ms`)
     } catch (err) {
       console.error('[Cloud] Shutdown error:', err)
+    }
+  }
+
+  async _uploadLogFile() {
+    if (!this.currentTask?.id || !this.supabase.storage) return
+
+    const logPath = join(this.dataDir, 'logs', `${this.currentTask.id}.jsonl`)
+    try {
+      const fileStat = await stat(logPath)
+      if (fileStat.size >= 5 * 1024 * 1024) return // skip if over 5MB
+
+      const logContent = await readFile(logPath)
+      await this.supabase.storage
+        .from('task-logs')
+        .upload(`${this.currentTask.id}.jsonl`, logContent, {
+          contentType: 'application/x-ndjson',
+          upsert: true,
+        })
+    } catch {
+      // Log file doesn't exist or upload failed — not critical
     }
   }
 }

--- a/tests/unit/broker/gracefulShutdown.test.js
+++ b/tests/unit/broker/gracefulShutdown.test.js
@@ -102,4 +102,80 @@ describe('GracefulShutdown', () => {
     const hasTaskUpdate = updateCalls.some(c => c[0]?.status === 'queued')
     expect(hasTaskUpdate).toBe(false)
   })
+
+  describe('cost tracking', () => {
+    it('accumulates cost from addUsage calls', () => {
+      shutdown.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+      shutdown.addUsage('engineer', 'anthropic', 2000, 800, 0.025)
+
+      const summary = shutdown.getCostSummary()
+      expect(summary.totalInputTokens).toBe(3000)
+      expect(summary.totalOutputTokens).toBe(1300)
+      expect(summary.totalCostUsd).toBeCloseTo(0.04)
+      expect(summary.byAgent['pm'].inputTokens).toBe(1000)
+      expect(summary.byAgent['engineer'].inputTokens).toBe(2000)
+    })
+
+    it('persists cost data to Supabase on shutdown', async () => {
+      shutdown.addUsage('pm', 'anthropic', 1000, 500, 0.015)
+
+      await shutdown.execute()
+
+      // Find the task update call that has cost_tokens
+      const updateCalls = mockSupabase.update.mock.calls
+      const costUpdate = updateCalls.find(c => c[0]?.cost_tokens)
+      expect(costUpdate).toBeTruthy()
+      expect(costUpdate[0].cost_tokens.input).toBe(1000)
+      expect(costUpdate[0].cost_tokens.output).toBe(500)
+      expect(costUpdate[0].cost_usd).toBe(0.015)
+    })
+
+    it('skips cost update when no usage recorded', async () => {
+      await shutdown.execute()
+
+      const updateCalls = mockSupabase.update.mock.calls
+      const costUpdate = updateCalls.find(c => c[0]?.cost_tokens)
+      expect(costUpdate).toBeUndefined()
+    })
+
+    it('uploads log file to Supabase Storage if under size limit', async () => {
+      const { mkdtemp, writeFile } = await import('node:fs/promises')
+      const { join } = await import('node:path')
+      const { tmpdir } = await import('node:os')
+
+      const tmpDir = await mkdtemp(join(tmpdir(), 'gs-test-'))
+      const { mkdir } = await import('node:fs/promises')
+      await mkdir(join(tmpDir, 'logs'), { recursive: true })
+      await writeFile(join(tmpDir, 'logs', 'task-abc.jsonl'), '{"test":true}\n')
+
+      const mockUpload = vi.fn().mockResolvedValue({ error: null })
+      mockSupabase.storage = {
+        from: vi.fn(() => ({ upload: mockUpload }))
+      }
+
+      shutdown = new GracefulShutdown({
+        supabase: mockSupabase,
+        db: mockDb,
+        agents: mockAgents,
+        machineId: 'fly-machine-1',
+        currentTask: { id: 'task-abc', status: 'running' },
+        heartbeatInterval: null,
+        taskTimeout: null,
+        dataDir: tmpDir
+      })
+
+      await shutdown.execute()
+
+      expect(mockSupabase.storage.from).toHaveBeenCalledWith('task-logs')
+      expect(mockUpload).toHaveBeenCalledWith(
+        'task-abc.jsonl',
+        expect.any(Buffer),
+        expect.objectContaining({ contentType: 'application/x-ndjson' })
+      )
+
+      // Cleanup
+      const { rm } = await import('node:fs/promises')
+      await rm(tmpDir, { recursive: true, force: true })
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- **Gap 4**: Add Pi agent runtime (`@mariozechner/pi-coding-agent`) to Dockerfile runtime stage so `spawn('pi', ...)` works in cloud mode
- **Gap 7**: Add cost tracking (`addUsage`/`getCostSummary`) and log file upload to `GracefulShutdown` (Option B per architect — avoids CJS/ESM boundary issues)

## Changed Files

| File | Change |
|------|--------|
| `Dockerfile` | Add `npm install -g @mariozechner/pi-coding-agent` to runtime stage |
| `broker/lib/gracefulShutdown.js` | Add cost accumulation, Supabase cost persistence, and log file upload |
| `tests/unit/broker/gracefulShutdown.test.js` | Add 4 new tests for cost tracking and log upload |

## Test plan

- [x] Cost accumulation across multiple agents/providers
- [x] Cost data persisted to Supabase tasks table on shutdown
- [x] Cost update skipped when no usage recorded
- [x] Log file uploaded to Supabase Storage (task-logs bucket) if under 5MB
- [x] 4 new tests, 0 regressions (401 existing tests still pass)

## Notes

- The `task-logs` Supabase Storage bucket needs manual creation before deployment
- Pi binary version installed will be latest from npm — pin version if needed for reproducibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)